### PR TITLE
prepare histogram crate for publishing

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "histogram"
-version = "0.0.0"
+version = "0.7.0"
 edition = "2021"
-authors = ["Brian Martin <brayniac@gmail.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 license = "Apache-2.0"
 homepage = "https://github.com/pelikan-io/rustcommon/histogram"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
-thiserror = "1.0.34"
+thiserror = "1.0.38"
 
 [dev-dependencies]
-criterion = "0.3.6"
+criterion = "0.4.0"
 
 [[bench]]
 name = "bench"

--- a/histogram/README.md
+++ b/histogram/README.md
@@ -1,8 +1,7 @@
 # histogram
 
-A simple histogram implementation inspired by HDRHistogram and our base-2
-implementation from [ccommon]. It uses atomic counters to record increments for
-each value.
+A simple histogram implementation inspired by HDRHistogram and an new base-2
+implementation. It uses atomic counters to record increments for each value.
 
 ## Getting Started
 
@@ -23,7 +22,7 @@ Create a [new issue](https://github.com/pelikan-io/rustcommon/issues/new) on Git
 
 ## Authors
 
-* Brian Martin <brayniac@gmail.com>
+* Brian Martin <brian@pelikan.io>
 
 A full list of [contributors] can be found on GitHub.
 


### PR DESCRIPTION
Prepare the rustcommon histogram crate for publishing on crates.io
