### PR TITLE
add description to histogram crate metadata

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.7.0"
 edition = "2021"
 authors = ["Brian Martin <brian@pelikan.io>"]
 license = "Apache-2.0"
+description = "Fast and simple atomic histograms"
 homepage = "https://github.com/pelikan-io/rustcommon/histogram"
 repository = "https://github.com/pelikan-io/rustcommon"
 

--- a/histogram/README.md
+++ b/histogram/README.md
@@ -1,6 +1,6 @@
 # histogram
 
-A simple histogram implementation inspired by HDRHistogram and an new base-2
+A simple histogram implementation inspired by HDRHistogram and a new base-2
 implementation. It uses atomic counters to record increments for each value.
 
 ## Getting Started


### PR DESCRIPTION
Histogram crate was missing a description in its metadata, which prevents publishing to crates.io
