### PR TITLE
add description for metriken crate

### DIFF
--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
 	"Sean Lynch <seanl@twitter.com>",
 ]
 license = "Apache-2.0"
+description = "A fast and lightweight metrics library"
 homepage = "https://github.com/pelikan-io/rustcommon"
 repository = "https://github.com/pelikan-io/rustcommon"
 


### PR DESCRIPTION
Adds a description to the metriken crate metadata
