### PR TITLE
chore: update dependencies on rustcommon crates

### DIFF
--- a/heatmap/Cargo.toml
+++ b/heatmap/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/pelikan-io/rustcommon/heatmap"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
-clocksource = "0.6.0"
+clocksource = { version = "0.6.0", path = "../clocksource" }
 histogram = { version = "0.7.1", path = "../histogram" }
 parking_lot = "0.12.1"
 thiserror = "1.0.34"

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = [
 	"Brian Martin <brayniac@gmail.com>",
@@ -12,9 +12,9 @@ homepage = "https://github.com/pelikan-io/rustcommon"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
-clocksource = "0.6.0"
-heatmap = "0.7.0"
+clocksource = { version = "0.6.0", path = "../clocksource" }
+heatmap = { version = "0.7.1", path = "../heatmap" }
 linkme = "0.3.3"
 once_cell = "1.14.0"
 parking_lot = "0.12.1"
-metriken-derive = "0.1.0"
+metriken-derive = { version = "0.1.0", path = "./derive" }

--- a/ratelimit/Cargo.toml
+++ b/ratelimit/Cargo.toml
@@ -9,6 +9,6 @@ homepage = "https://github.com/pelikan-io/rustcommon/ratelimit"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
-clocksource = "0.6.0"
+clocksource = { version = "0.6.0", path = "../clocksource" }
 rand = "0.8.5"
 rand_distr = "0.4.3"

--- a/ringlog/Cargo.toml
+++ b/ringlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ringlog"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Brian Martin <brian@pelikan.io>"]
@@ -10,7 +10,7 @@ repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
 ahash = "0.8.0"
-clocksource = "0.6.0"
-metriken = "0.1.0"
+clocksource = { version = "0.6.0", path = "../clocksource" }
+metriken = { version = "0.1.1", path = "../metriken" }
 log = { version = "0.4.17", features = ["std"] }
 mpmc = "0.1.6"

--- a/switchboard/Cargo.toml
+++ b/switchboard/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/pelikan-io/rustcommon"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
-awaken = "0.1.0"
+awaken = { version = "0.1.0", path = "../awaken" }
 crossbeam-queue = "0.3.8"
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -9,12 +9,12 @@ homepage = "https://github.com/pelikan-io/rustcommon/waterfall"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
-clocksource = "0.6.0"
+clocksource = { version = "0.6.0", path = "../clocksource" }
 dejavu = "2.37.0"
 image = "0.24.3"
 log = "0.4.17"
-heatmap = "0.7.0"
-histogram = "0.7.0"
+heatmap = { version = "0.7.1", path = "../heatmap" }
+histogram = { version = "0.7.1", path = "../histogram" }
 rusttype = "0.9.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Updates the dependencies on rustcommon crates. This ensures that the fixed version of `heatmap` is used throughout. Additionally, changes all dependencies on rustcommon crates to include a path in addition to a version. This will make changes that effect multiple crates easier in the future.
