### PR TITLE
chore: prepare waterfall crate for release

### DIFF
--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterfall"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Missed a bump of the version number for `waterfall` in #19
