### PR TITLE
feat: Add a summary method to Heatmap to access the summary histogram

### DIFF
--- a/heatmap/src/heatmap.rs
+++ b/heatmap/src/heatmap.rs
@@ -202,6 +202,15 @@ impl Heatmap {
         self.summary.percentile(percentile).map_err(Error::from)
     }
 
+    /// Access the summary histogram of this heatmap.
+    ///
+    /// Note that concurrent modifications to the heatmap will continue to show
+    /// up in the summary histogram while it is being read so sequential
+    /// queries may not return consistent results.
+    pub fn summary(&self) -> &Histogram {
+        &self.summary
+    }
+
     // Internal function which handles reuse of older windows to store newer
     /// values.
     fn tick(&self, time: Instant) {


### PR DESCRIPTION
I would like to be able to access the buckets of the summary histogram. Using the iterator implementation for `&Heatmap` it is possible to get access to all the other component histograms but not the summary one. This PR just adds a `summary` method to `Heatmap` which returns a reference to the summary histogram.