### PR TITLE
feat: Add `Heatmap::iter` method

### DIFF
--- a/heatmap/src/heatmap.rs
+++ b/heatmap/src/heatmap.rs
@@ -202,6 +202,12 @@ impl Heatmap {
         self.summary.percentile(percentile).map_err(Error::from)
     }
 
+    /// Creates an iterator to iterate over the component histograms of this
+    /// heatmap.
+    pub fn iter(&self) -> Iter {
+        self.into_iter()
+    }
+
     // Internal function which handles reuse of older windows to store newer
     /// values.
     fn tick(&self, time: Instant) {


### PR DESCRIPTION
`&Heatmap` implements `IntoIterator` but it does not have an `iter` method. This is somewhat confusing since in most cases where a type `&T` implements `IntoIterator` `T` also has an `iter` method that does the same thing. All this PR does is address this missing method.  
