### PR TITLE
heatmap: allow recording sample into older slice

### DIFF
--- a/heatmap/src/heatmap.rs
+++ b/heatmap/src/heatmap.rs
@@ -311,7 +311,9 @@ impl Heatmap {
 
                     // check to make sure it's actually an old slice. A newly
                     // created heatmap will have all slices in the future.
-                    if self.slices[to_clear].start.load(Ordering::Relaxed) < self.start.load(Ordering::Relaxed) {
+                    if self.slices[to_clear].start.load(Ordering::Relaxed)
+                        < self.start.load(Ordering::Relaxed)
+                    {
                         // subtract and clear
                         let _ = self
                             .summary

--- a/heatmap/src/window.rs
+++ b/heatmap/src/window.rs
@@ -2,13 +2,31 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use crate::AtomicInstant;
 use clocksource::*;
+use core::sync::atomic::Ordering;
 use histogram::Histogram;
 
 pub struct Window<'a> {
     pub(crate) start: Instant<Nanoseconds<u64>>,
     pub(crate) stop: Instant<Nanoseconds<u64>>,
     pub(crate) histogram: &'a Histogram,
+}
+
+pub(crate) struct OwnedWindow {
+    pub(crate) start: AtomicInstant,
+    pub(crate) stop: AtomicInstant,
+    pub(crate) histogram: Histogram,
+}
+
+impl Clone for OwnedWindow {
+    fn clone(&self) -> Self {
+        Self {
+            start: AtomicInstant::new(self.start.load(Ordering::Relaxed)),
+            stop: AtomicInstant::new(self.stop.load(Ordering::Relaxed)),
+            histogram: self.histogram.clone(),
+        }
+    }
 }
 
 impl<'a> Window<'a> {


### PR DESCRIPTION
Previously, the heatmap would only record into the "current" slice. This meant that we could only record past events into the most recent time slice.

This change adds some additional fields to the heatmap to track the represented span of time for the overall heatmap and each time slice. We leave a fast path in-place for when the sample time falls into the span for the current slice. If it does not, we calculate the correct offset into the heatmap and record into that older slice.

By making this change, we can correctly record based on event start time instead of event stop time.
