### PR TITLE
chore: release heatmap and metriken

### DIFF
--- a/heatmap/Cargo.toml
+++ b/heatmap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heatmap"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = [
 	"Brian Martin <brayniac@gmail.com>",
@@ -13,7 +13,7 @@ repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
 clocksource = { version = "0.6.0", path = "../clocksource" }
-heatmap = { version = "0.7.1", path = "../heatmap" }
+heatmap = { version = "0.7.3", path = "../heatmap" }
 linkme = "0.3.3"
 once_cell = "1.14.0"
 parking_lot = "0.12.1"


### PR DESCRIPTION
Update version numbers and prepare for release heatmap 0.7.3 and metriken 0.1.2
