### PR TITLE
fix: histogram panics

### DIFF
--- a/histogram/src/histogram.rs
+++ b/histogram/src/histogram.rs
@@ -391,6 +391,10 @@ impl Histogram {
     }
 
     fn high(&self, idx: usize) -> u64 {
+        if idx == self.buckets.len() - 1 {
+            return self.N;
+        }
+
         let idx = idx as u64;
         let m = self.m as u64;
         let r = self.r as u64;

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -36,7 +36,7 @@ mod tests {
     }
 
     #[test]
-    fn percentiles() {
+    fn percentile() {
         let histogram = Histogram::new(0, 2, 10).unwrap();
 
         for v in 1..1024 {
@@ -44,5 +44,28 @@ mod tests {
             assert!(histogram.percentile(100.0).map(|b| b.high()).unwrap_or(0) >= v);
             assert!(histogram.percentile(100.0).map(|b| b.low()).unwrap_or(0) <= v);
         }
+    }
+
+    #[test]
+    fn percentiles() {
+        let histogram = Histogram::builder().build().unwrap();
+        histogram.increment(1, 1).unwrap();
+        histogram.increment(10000000, 1).unwrap();
+
+        let percentiles = histogram.percentiles(&[25.0, 75.0]).unwrap();
+
+        assert_eq!(histogram.percentile(25.0).map(|b| b.high()), Ok(1));
+        assert_eq!(histogram.percentile(75.0).map(|b| b.high()), Ok(10010623));
+
+        for p in &percentiles {
+            println!(
+                "{} {} {}",
+                p.percentile(),
+                p.bucket().low(),
+                p.bucket().count()
+            );
+        }
+
+        assert_eq!(percentiles.get(0).map(|b| b.bucket().high()), Some(1));
     }
 }

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -36,18 +36,76 @@ mod tests {
     }
 
     #[test]
-    fn percentile() {
+    fn percentiles_1() {
         let histogram = Histogram::new(0, 2, 10).unwrap();
 
         for v in 1..1024 {
             assert!(histogram.increment(v, 1).is_ok());
+            assert_eq!(histogram.percentile(0.0).map(|b| b.high()), Ok(1));
+
             assert!(histogram.percentile(100.0).map(|b| b.high()).unwrap_or(0) >= v);
             assert!(histogram.percentile(100.0).map(|b| b.low()).unwrap_or(0) <= v);
         }
+
+        let percentiles: Vec<(u64, u64)> = histogram
+            .percentiles(&[1.0, 10.0, 25.0, 50.0, 75.0, 90.0, 99.0])
+            .unwrap()
+            .iter()
+            .map(|p| (p.bucket().low(), p.bucket().high()))
+            .collect();
+
+        // this histogram config doesn't have much resolution, which results in
+        // the upper percentiles falling into buckets that are rather wide
+        assert_eq!(
+            &percentiles,
+            &[
+                (8, 11),
+                (96, 127),
+                (256, 383),
+                (512, 767),
+                (768, 1023),
+                (768, 1023),
+                (768, 1023)
+            ]
+        );
     }
 
     #[test]
-    fn percentiles() {
+    fn percentiles_2() {
+        let histogram = Histogram::new(0, 5, 10).unwrap();
+
+        for v in 1..1024 {
+            assert!(histogram.increment(v, 1).is_ok());
+            assert_eq!(histogram.percentile(0.0).map(|b| b.high()), Ok(1));
+
+            assert!(histogram.percentile(100.0).map(|b| b.high()).unwrap_or(0) >= v);
+            assert!(histogram.percentile(100.0).map(|b| b.low()).unwrap_or(0) <= v);
+        }
+
+        let percentiles: Vec<(u64, u64)> = histogram
+            .percentiles(&[1.0, 10.0, 25.0, 50.0, 75.0, 90.0, 99.0])
+            .unwrap()
+            .iter()
+            .map(|p| (p.bucket().low(), p.bucket().high()))
+            .collect();
+
+        // this histogram config has enough resolution to keep the error lower
+        assert_eq!(
+            &percentiles,
+            &[
+                (11, 11),
+                (100, 103),
+                (256, 271),
+                (512, 543),
+                (768, 799),
+                (896, 927),
+                (992, 1023)
+            ]
+        );
+    }
+
+    #[test]
+    fn percentiles_3() {
         let histogram = Histogram::builder().build().unwrap();
         histogram.increment(1, 1).unwrap();
         histogram.increment(10000000, 1).unwrap();
@@ -57,15 +115,10 @@ mod tests {
         assert_eq!(histogram.percentile(25.0).map(|b| b.high()), Ok(1));
         assert_eq!(histogram.percentile(75.0).map(|b| b.high()), Ok(10010623));
 
-        for p in &percentiles {
-            println!(
-                "{} {} {}",
-                p.percentile(),
-                p.bucket().low(),
-                p.bucket().count()
-            );
-        }
-
         assert_eq!(percentiles.get(0).map(|b| b.bucket().high()), Some(1));
+        assert_eq!(
+            percentiles.get(1).map(|b| b.bucket().high()),
+            Some(10010623)
+        );
     }
 }


### PR DESCRIPTION
Addresses two panic cases within this crate and fixes the
percentiles()` function to return the correct results.

There's a wrapping math operation which occurs when calculating the
upper bound of the highest bucket when the histogram is configured
to cover the entired 64bit range. This is addressed by returning
the histogram's max value if the bucket is the last bucket.

Additionally, as reported in #25 we perform a bounds check after
we index into an array in the `percentiles()` function. This will
reliably cause a panic. However, there are also issues with the
returned results after correcting the panic condition.

Fixes the logic in the `percentiles()` function to both avoid
out of bounds access and return the correct results.