### PR TITLE
fix a histogram builder off-by-one in Builder::min_resolution

### DIFF
--- a/histogram/src/histogram.rs
+++ b/histogram/src/histogram.rs
@@ -481,3 +481,23 @@ impl<'a> Iterator for HistogramIter<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_min_resolution() {
+        let h = Histogram::builder()
+            .min_resolution(std::num::NonZeroU64::new(10).unwrap())
+            .build()
+            .unwrap();
+        assert_eq!(h.m, 3); // 2^3 == 8
+
+        let h = Histogram::builder()
+            .min_resolution(std::num::NonZeroU64::new(8).unwrap())
+            .build()
+            .unwrap();
+        assert_eq!(h.m, 3);// 2^3 == 8
+    }
+}

--- a/histogram/src/histogram.rs
+++ b/histogram/src/histogram.rs
@@ -6,6 +6,7 @@ use crate::*;
 
 use core::sync::atomic::AtomicU32;
 use core::sync::atomic::Ordering;
+use std::num::NonZeroU64;
 
 /// A `Histogram` groups recorded values into buckets of similar values and
 /// tracks counts for recorded values that fall into those ranges.
@@ -55,8 +56,8 @@ impl Builder {
     /// largest power of two that is less than or equal to the provided value.
     /// For example, if the minimum resolution is set to 10, the width of the
     /// smallest bucket will be 8.
-    pub fn min_resolution(mut self, width: u64) -> Self {
-        self.m = 64 - width.leading_zeros();
+    pub fn min_resolution(mut self, width: NonZeroU64) -> Self {
+        self.m = 63 - width.leading_zeros();
         self
     }
 

--- a/histogram/src/histogram.rs
+++ b/histogram/src/histogram.rs
@@ -498,6 +498,6 @@ mod tests {
             .min_resolution(std::num::NonZeroU64::new(8).unwrap())
             .build()
             .unwrap();
-        assert_eq!(h.m, 3);// 2^3 == 8
+        assert_eq!(h.m, 3); // 2^3 == 8
     }
 }


### PR DESCRIPTION
I haven't checked to see if this off-by-one exists in other places. This fixes the bug and adds a test. 

I'm not sure about the use of `NonZeroU64` - maybe that condition should be checked with an assert instead?