### PR TITLE
histogram: Fix decrement function

### DIFF
--- a/histogram/src/histogram.rs
+++ b/histogram/src/histogram.rs
@@ -176,7 +176,7 @@ impl Histogram {
         }
 
         let index = self.bucket_index(value);
-        self.buckets[index].fetch_add(count, Ordering::Relaxed);
+        self.buckets[index].fetch_sub(count, Ordering::Relaxed);
 
         Ok(())
     }

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -121,4 +121,22 @@ mod tests {
             Some(10010623)
         );
     }
+
+    #[test]
+    fn test_increment_and_decrement() {
+        let histogram = Histogram::builder().build().unwrap();
+        assert_eq!(
+            histogram.percentile(0.0).map(|b| b.count()),
+            Err(Error::Empty)
+        );
+
+        histogram.increment(1, 1).unwrap();
+        assert_eq!(histogram.percentile(0.0).map(|b| b.count()), Ok(1));
+
+        histogram.decrement(1, 1).unwrap();
+        assert_eq!(
+            histogram.percentile(0.0).map(|b| b.count()),
+            Err(Error::Empty)
+        );
+    }
 }


### PR DESCRIPTION
The decrement function currently increments the value. Fix by using
fetch_sub() instead of fetch_add().
