### PR TITLE
histogram: export histogram resolution parameters

### DIFF
--- a/histogram/src/histogram.rs
+++ b/histogram/src/histogram.rs
@@ -140,6 +140,14 @@ impl Histogram {
         Builder { m: 0, r: 10, n: 30 }
     }
 
+    /// Gets the values that have been used for the creation of the histogram.
+    ///
+    /// These values represent (m, r, n), i.e., the minimum resolution, the
+    /// minimum resolution range, and the maximum value supported.
+    pub fn parameters(&self) -> (u32, u32, u32) {
+        (self.m, self.r, self.n)
+    }
+
     /// Resets the `Histogram` by zeroing out the count for every bucket.
     pub fn clear(&self) {
         for bucket in self.buckets.iter() {
@@ -482,22 +490,5 @@ impl<'a> Iterator for HistogramIter<'a> {
         } else {
             None
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_min_resolution() {
-        let h = Histogram::builder().min_resolution(10).build().unwrap();
-        assert_eq!(h.m, 3);
-
-        let h = Histogram::builder().min_resolution(8).build().unwrap();
-        assert_eq!(h.m, 3);
-
-        let h = Histogram::builder().min_resolution(0).build().unwrap();
-        assert_eq!(h.m, 0);
     }
 }

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -17,6 +17,28 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_builder() {
+        let h = Histogram::builder().build().unwrap();
+        let p = h.parameters();
+
+        assert_eq!(p.0, 0);
+        assert_eq!(p.1, 10);
+        assert_eq!(p.2, 30);
+    }
+
+    #[test]
+    fn test_min_resolution() {
+        let h = Histogram::builder().min_resolution(10).build().unwrap();
+        assert_eq!(h.parameters().0, 3);
+
+        let h = Histogram::builder().min_resolution(8).build().unwrap();
+        assert_eq!(h.parameters().0, 3);
+
+        let h = Histogram::builder().min_resolution(0).build().unwrap();
+        assert_eq!(h.parameters().0, 0);
+    }
+
+    #[test]
     // run some test cases for various histogram sizes
     fn num_buckets() {
         let histogram = Histogram::new(0, 2, 10).unwrap();


### PR DESCRIPTION
The buckets in a histogram are deterministically generated depending on the m, r, and n parameters representing the values and the granularity being tracked. Exporting these allows for the generation of identical histograms.
