### PR TITLE
Update authorship info for the metriken crate

### DIFF
--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "metriken"
-version = "0.1.4"
+version = "0.2.0-alpha"
 edition = "2021"
 authors = [
-	"Brian Martin <brayniac@gmail.com>",
-	"Sean Lynch <seanl@twitter.com>",
+	"Brian Martin <brian@iop.systems>",
+	"Sean Lynch <sean@iop.systems>",
 ]
 license = "Apache-2.0"
 description = "A fast and lightweight metrics library"

--- a/metriken/LICENSE-APACHE
+++ b/metriken/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/ringlog/Cargo.toml
+++ b/ringlog/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/pelikan-io/rustcommon"
 [dependencies]
 ahash = "0.8.0"
 clocksource = { version = "0.6.0", path = "../clocksource" }
-metriken = { version = "0.1.1", path = "../metriken" }
+metriken = { version = "0.1.1" }
 log = { version = "0.4.17", features = ["std"] }
 mpmc = "0.1.6"


### PR DESCRIPTION
This is the first PR in a series for updating metriken. All it does is update the authorship info, version, and detach ringlog from metriken so that CI passes.
