### PR TITLE
feat(metriken): Add a `Value` type to abstract over different metriken metric types

### DIFF
--- a/metriken/src/counter.rs
+++ b/metriken/src/counter.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::Metric;
+use crate::{Metric, Value};
 use std::any::Any;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -67,5 +67,9 @@ impl Counter {
 impl Metric for Counter {
     fn as_any(&self) -> Option<&dyn Any> {
         Some(self)
+    }
+
+    fn value(&self) -> Option<Value> {
+        Some(Value::Counter(self.value()))
     }
 }

--- a/metriken/src/gauge.rs
+++ b/metriken/src/gauge.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::Metric;
+use crate::{Metric, Value};
 use std::any::Any;
 use std::sync::atomic::{AtomicI64, Ordering};
 
@@ -90,5 +90,9 @@ impl Gauge {
 impl Metric for Gauge {
     fn as_any(&self) -> Option<&dyn Any> {
         Some(self)
+    }
+
+    fn value(&self) -> Option<Value> {
+        Some(Value::Gauge(self.value()))
     }
 }

--- a/metriken/src/heatmap.rs
+++ b/metriken/src/heatmap.rs
@@ -1,4 +1,4 @@
-use crate::Metric;
+use crate::{Metric, Value};
 
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -101,5 +101,9 @@ impl Heatmap {
 impl Metric for Heatmap {
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
+    }
+
+    fn value(&self) -> Option<Value> {
+        Some(Value::Heatmap(self))
     }
 }

--- a/metriken/src/lazy.rs
+++ b/metriken/src/lazy.rs
@@ -116,4 +116,8 @@ impl<T: Metric, F: Send + 'static> Metric for Lazy<T, F> {
             None => None,
         }
     }
+
+    fn value(&self) -> Option<crate::Value> {
+        Lazy::get(self).and_then(|metric| metric.value())
+    }
 }

--- a/metriken/src/lib.rs
+++ b/metriken/src/lib.rs
@@ -184,6 +184,35 @@ pub trait Metric: Send + Sync + 'static {
     ///
     /// [`Any`]: std::any::Any
     fn as_any(&self) -> Option<&dyn Any>;
+
+    /// Get the value of the current metric, should it be enabled.
+    ///
+    /// # Note to Implementors
+    /// If your metric's value does not correspond to one of the variants of
+    /// [`Value`] then return [`Value::Other`] and metric consumers can use
+    /// [`as_any`](crate::Metric::as_any) to specifically handle your metric.
+    fn value(&self) -> Option<Value>;
+}
+
+/// The value of a metric.
+///
+/// See [`Metric::value`].
+#[non_exhaustive]
+#[derive(Clone)]
+pub enum Value<'a> {
+    /// A counter value.
+    Counter(u64),
+
+    /// A gauge value.
+    Gauge(i64),
+
+    Heatmap(&'a Heatmap),
+
+    /// The value of the metric could not be represented using the other
+    /// `Value` variants.
+    ///
+    /// Use [`Metric::as_any`] to specifically handle the type of this metric.
+    Other,
 }
 
 /// A statically declared metric entry.

--- a/metriken/src/null.rs
+++ b/metriken/src/null.rs
@@ -12,4 +12,8 @@ impl Metric for NullMetric {
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         None
     }
+
+    fn value(&self) -> Option<crate::Value> {
+        None
+    }
 }


### PR DESCRIPTION
As discussed when we were reviewing the changes to metriken. This is somewhat the minimal possible design to work for rezolus and I anticipate it being changed in the future as we try to use it.