### PR TITLE
feat(metriken): wire up the formatter

### DIFF
--- a/metriken/derive/src/metric.rs
+++ b/metriken/derive/src/metric.rs
@@ -146,7 +146,7 @@ pub(crate) fn metric(
     let formatter = args
         .formatter
         .map(|fmt| fmt.value)
-        .unwrap_or_else(|| parse_quote!(&#krate::default_formatter));
+        .unwrap_or_else(|| parse_quote!(#krate::default_formatter));
 
     let attrs: Vec<_> = metadata
         .0

--- a/metriken/derive/src/metric.rs
+++ b/metriken/derive/src/metric.rs
@@ -143,7 +143,7 @@ pub(crate) fn metric(
         .map(|SingleArg { value, .. }| parse_quote!(Some(#value)))
         .unwrap_or_else(|| parse_quote!(None));
 
-    let _formatter = args
+    let formatter = args
         .formatter
         .map(|fmt| fmt.value)
         .unwrap_or_else(|| parse_quote!(&#krate::default_formatter));
@@ -172,6 +172,7 @@ pub(crate) fn metric(
             #name,
             #description,
             &__METADATA,
+            #formatter,
         );
 
         #static_expr

--- a/metriken/src/dynmetrics.rs
+++ b/metriken/src/dynmetrics.rs
@@ -16,7 +16,7 @@ use std::ops::Deref;
 use std::pin::Pin;
 
 use crate::null::NullMetric;
-use crate::{Metadata, Metric, MetricEntry, MetricWrapper};
+use crate::{default_formatter, Format, Metadata, Metric, MetricEntry, MetricWrapper};
 
 // We use parking_lot here since it avoids lock poisioning
 use parking_lot::{const_rwlock, RwLock, RwLockReadGuard};
@@ -64,6 +64,7 @@ pub struct MetricBuilder {
     name: Cow<'static, str>,
     desc: Option<Cow<'static, str>>,
     metadata: HashMap<String, String>,
+    formatter: &'static dyn Fn(&MetricEntry, Format) -> String,
 }
 
 impl MetricBuilder {
@@ -73,6 +74,7 @@ impl MetricBuilder {
             name: name.into(),
             desc: None,
             metadata: HashMap::new(),
+            formatter: &default_formatter,
         }
     }
 
@@ -95,6 +97,7 @@ impl MetricBuilder {
             name: self.name,
             description: self.desc,
             metadata: Metadata::new(self.metadata),
+            formatter: self.formatter,
         }
     }
 

--- a/metriken/src/dynmetrics.rs
+++ b/metriken/src/dynmetrics.rs
@@ -74,7 +74,7 @@ impl MetricBuilder {
             name: name.into(),
             desc: None,
             metadata: HashMap::new(),
-            formatter: &default_formatter,
+            formatter: default_formatter,
         }
     }
 
@@ -87,6 +87,11 @@ impl MetricBuilder {
     /// Add a new key-value metadata entry.
     pub fn metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn formatter(mut self, formatter: fn(&MetricEntry, Format) -> String) -> Self {
+        self.formatter = formatter;
         self
     }
 

--- a/metriken/src/dynmetrics.rs
+++ b/metriken/src/dynmetrics.rs
@@ -64,7 +64,7 @@ pub struct MetricBuilder {
     name: Cow<'static, str>,
     desc: Option<Cow<'static, str>>,
     metadata: HashMap<String, String>,
-    formatter: &'static dyn Fn(&MetricEntry, Format) -> String,
+    formatter: fn(&MetricEntry, Format) -> String,
 }
 
 impl MetricBuilder {

--- a/metriken/src/formatter.rs
+++ b/metriken/src/formatter.rs
@@ -2,35 +2,37 @@ use crate::MetricEntry;
 
 #[non_exhaustive]
 pub enum Format {
-	/// A metrics format that represents the metric using only a simple name. If
-	/// a metric's name depends on metadata associated with it, the formatter
-	/// should ensure that the output name is unique.
-	///
-	/// Examples:
-	/// `cpu/usage/user`
-	/// `cpu/usage/system`
-	/// `network/eth0/transmit/bytes`
-	Simple,
-	/// A metrics format that represents the metric using a name and associated
-	/// metadata in the Prometheus exposition format.
-	///
-	/// Examples:
-	/// `cpu_usage{mode="user"}`
-	/// `cpu_usage{mode="system"}`
-	/// `network_transmit_bytes{device="eth0"}`
-	Prometheus,
+    /// A metrics format that represents the metric using only a simple name. If
+    /// a metric's name depends on metadata associated with it, the formatter
+    /// should ensure that the output name is unique.
+    ///
+    /// Examples:
+    /// `cpu/usage/user`
+    /// `cpu/usage/system`
+    /// `network/eth0/transmit/bytes`
+    Simple,
+    /// A metrics format that represents the metric using a name and associated
+    /// metadata in the Prometheus exposition format.
+    ///
+    /// Examples:
+    /// `cpu_usage{mode="user"}`
+    /// `cpu_usage{mode="system"}`
+    /// `network_transmit_bytes{device="eth0"}`
+    Prometheus,
 }
 
 pub fn default_formatter(metric: &MetricEntry, format: Format) -> String {
-	match format {
-		Format::Prometheus => {
-			let metadata: Vec<String> = metric.metadata().iter().map(|(key, value)| { format!("{key}=\"{value}\"")}).collect();
-			let metadata = metadata.join(", ");
+    match format {
+        Format::Prometheus => {
+            let metadata: Vec<String> = metric
+                .metadata()
+                .iter()
+                .map(|(key, value)| format!("{key}=\"{value}\""))
+                .collect();
+            let metadata = metadata.join(", ");
 
-			format!("{}{{{metadata}}}", metric.name())
-		}
-		_ => {
-			metric.name().to_string()
-		}
-	}
+            format!("{}{{{metadata}}}", metric.name())
+        }
+        _ => metric.name().to_string(),
+    }
 }

--- a/metriken/src/formatter.rs
+++ b/metriken/src/formatter.rs
@@ -32,7 +32,7 @@ pub fn default_formatter(metric: &MetricEntry, format: Format) -> String {
             let metadata = metadata.join(", ");
 
             if metadata.is_empty() {
-                format!("{}", metric.name())
+                metric.name().to_string()
             } else {
                 format!("{}{{{metadata}}}", metric.name())
             }

--- a/metriken/src/formatter.rs
+++ b/metriken/src/formatter.rs
@@ -1,0 +1,36 @@
+use crate::MetricEntry;
+
+#[non_exhaustive]
+pub enum Format {
+	/// A metrics format that represents the metric using only a simple name. If
+	/// a metric's name depends on metadata associated with it, the formatter
+	/// should ensure that the output name is unique.
+	///
+	/// Examples:
+	/// `cpu/usage/user`
+	/// `cpu/usage/system`
+	/// `network/eth0/transmit/bytes`
+	Simple,
+	/// A metrics format that represents the metric using a name and associated
+	/// metadata in the Prometheus exposition format.
+	///
+	/// Examples:
+	/// `cpu_usage{mode="user"}`
+	/// `cpu_usage{mode="system"}`
+	/// `network_transmit_bytes{device="eth0"}`
+	Prometheus,
+}
+
+pub fn default_formatter(metric: &MetricEntry, format: Format) -> String {
+	match format {
+		Format::Prometheus => {
+			let metadata: Vec<String> = metric.metadata().iter().map(|(key, value)| { format!("{key}=\"{value}\"")}).collect();
+			let metadata = metadata.join(", ");
+
+			format!("{}{{{metadata}}}", metric.name())
+		}
+		_ => {
+			metric.name().to_string()
+		}
+	}
+}

--- a/metriken/src/formatter.rs
+++ b/metriken/src/formatter.rs
@@ -31,7 +31,11 @@ pub fn default_formatter(metric: &MetricEntry, format: Format) -> String {
                 .collect();
             let metadata = metadata.join(", ");
 
-            format!("{}{{{metadata}}}", metric.name())
+            if metadata.is_empty() {
+                format!("{}", metric.name())
+            } else {
+                format!("{}{{{metadata}}}", metric.name())
+            }
         }
         _ => metric.name().to_string(),
     }

--- a/metriken/src/lib.rs
+++ b/metriken/src/lib.rs
@@ -154,7 +154,7 @@ pub mod export {
         name: &'static str,
         description: Option<&'static str>,
         metadata: &'static phf::Map<&'static str, &'static str>,
-        formatter: &'static dyn Fn(&crate::MetricEntry, crate::Format) -> String,
+        formatter: fn(&crate::MetricEntry, crate::Format) -> String,
     ) -> crate::MetricEntry {
         use std::borrow::Cow;
 
@@ -225,7 +225,7 @@ pub struct MetricEntry {
     name: Cow<'static, str>,
     description: Option<Cow<'static, str>>,
     metadata: Metadata,
-    formatter: &'static dyn Fn(&Self, Format) -> String,
+    formatter: fn(&Self, Format) -> String,
 }
 
 impl MetricEntry {

--- a/metriken/src/lib.rs
+++ b/metriken/src/lib.rs
@@ -87,6 +87,7 @@ macro_rules! used_in_docs {
 }
 
 mod counter;
+mod formatter;
 mod gauge;
 mod heatmap;
 mod lazy;
@@ -100,6 +101,7 @@ pub mod dynmetrics;
 
 pub use crate::counter::Counter;
 pub use crate::dynmetrics::{DynBoxedMetric, DynPinnedMetric, MetricBuilder};
+pub use crate::formatter::{default_formatter, Format};
 pub use crate::gauge::Gauge;
 pub use crate::heatmap::Heatmap;
 pub use crate::lazy::Lazy;
@@ -152,6 +154,7 @@ pub mod export {
         name: &'static str,
         description: Option<&'static str>,
         metadata: &'static phf::Map<&'static str, &'static str>,
+        formatter: &'static dyn Fn(&crate::MetricEntry, crate::Format) -> String,
     ) -> crate::MetricEntry {
         use std::borrow::Cow;
 
@@ -163,6 +166,7 @@ pub mod export {
                 None => None,
             },
             metadata: Metadata::new_static(metadata),
+            formatter,
         }
     }
 }
@@ -221,6 +225,7 @@ pub struct MetricEntry {
     name: Cow<'static, str>,
     description: Option<Cow<'static, str>>,
     metadata: Metadata,
+    formatter: &'static dyn Fn(&Self, Format) -> String,
 }
 
 impl MetricEntry {
@@ -242,6 +247,11 @@ impl MetricEntry {
     /// Access the [`Metadata`] associated with this metrics entry.
     pub fn metadata(&self) -> &Metadata {
         &self.metadata
+    }
+
+    /// Format the metric into a string with the given format.
+    pub fn formatted(&self, format: Format) -> String {
+        (self.formatter)(self, format)
     }
 
     /// Checks whether `metric` is the metric for this entry.

--- a/metriken/tests/formatter.rs
+++ b/metriken/tests/formatter.rs
@@ -47,7 +47,10 @@ fn instance_a() {
     assert_eq!(metrics.len(), 3);
     assert_eq!(metric.name(), "metric");
     assert_eq!(metric.formatted(Format::Simple), "metric_instance_a");
-    assert_eq!(metric.formatted(Format::Prometheus), "metric{instance=\"a\"}");
+    assert_eq!(
+        metric.formatted(Format::Prometheus),
+        "metric{instance=\"a\"}"
+    );
 }
 
 #[test]
@@ -58,5 +61,8 @@ fn instance_b() {
     assert_eq!(metrics.len(), 3);
     assert_eq!(metric.name(), "metric");
     assert_eq!(metric.formatted(Format::Simple), "metric_instance_b");
-    assert_eq!(metric.formatted(Format::Prometheus), "metric{instance=\"b\"}");
+    assert_eq!(
+        metric.formatted(Format::Prometheus),
+        "metric{instance=\"b\"}"
+    );
 }

--- a/metriken/tests/formatter.rs
+++ b/metriken/tests/formatter.rs
@@ -3,8 +3,12 @@ use metriken::*;
 fn custom_formatter(metric: &MetricEntry, format: Format) -> String {
     match format {
         Format::Simple => {
-            format!("{}_instance_{}", metric.name(), metric.metadata().get("instance").unwrap_or("unknown"))
-        },
+            format!(
+                "{}_instance_{}",
+                metric.name(),
+                metric.metadata().get("instance").unwrap_or("unknown")
+            )
+        }
         _ => metriken::default_formatter(metric, format),
     }
 }
@@ -31,10 +35,7 @@ fn metric_name_as_expected() {
 #[test]
 fn metric_name_and_description_as_expected() {
     let metrics = metrics().static_metrics();
-    let metric = metrics
-        .iter()
-        .find(|entry| entry.is(&METRIC_B))
-        .unwrap();
+    let metric = metrics.iter().find(|entry| entry.is(&METRIC_B)).unwrap();
 
     assert_eq!(metrics.len(), 2);
     assert_eq!(metric.name(), "metric");

--- a/metriken/tests/formatter.rs
+++ b/metriken/tests/formatter.rs
@@ -13,6 +13,9 @@ fn custom_formatter(metric: &MetricEntry, format: Format) -> String {
     }
 }
 
+#[metric(name = "metric", formatter = &custom_formatter)]
+static METRIC: Counter = Counter::new();
+
 #[metric(name = "metric", metadata = { instance = "a"}, formatter = &custom_formatter)]
 static METRIC_A: Counter = Counter::new();
 
@@ -20,24 +23,40 @@ static METRIC_A: Counter = Counter::new();
 static METRIC_B: Counter = Counter::new();
 
 #[test]
-fn metric_name_as_expected() {
+fn no_metadata() {
+    let metrics = metrics().static_metrics();
+    let metric = metrics //
+        .iter()
+        .find(|entry| entry.is(&METRIC))
+        .unwrap();
+
+    assert_eq!(metrics.len(), 3);
+    assert_eq!(metric.name(), "metric");
+    assert_eq!(metric.formatted(Format::Simple), "metric_instance_unknown");
+    assert_eq!(metric.formatted(Format::Prometheus), "metric");
+}
+
+#[test]
+fn instance_a() {
     let metrics = metrics().static_metrics();
     let metric = metrics //
         .iter()
         .find(|entry| entry.is(&METRIC_A))
         .unwrap();
 
-    assert_eq!(metrics.len(), 2);
+    assert_eq!(metrics.len(), 3);
     assert_eq!(metric.name(), "metric");
     assert_eq!(metric.formatted(Format::Simple), "metric_instance_a");
+    assert_eq!(metric.formatted(Format::Prometheus), "metric{instance=\"a\"}");
 }
 
 #[test]
-fn metric_name_and_description_as_expected() {
+fn instance_b() {
     let metrics = metrics().static_metrics();
     let metric = metrics.iter().find(|entry| entry.is(&METRIC_B)).unwrap();
 
-    assert_eq!(metrics.len(), 2);
+    assert_eq!(metrics.len(), 3);
     assert_eq!(metric.name(), "metric");
     assert_eq!(metric.formatted(Format::Simple), "metric_instance_b");
+    assert_eq!(metric.formatted(Format::Prometheus), "metric{instance=\"b\"}");
 }

--- a/metriken/tests/formatter.rs
+++ b/metriken/tests/formatter.rs
@@ -13,13 +13,13 @@ fn custom_formatter(metric: &MetricEntry, format: Format) -> String {
     }
 }
 
-#[metric(name = "metric", formatter = &custom_formatter)]
+#[metric(name = "metric", formatter = custom_formatter)]
 static METRIC: Counter = Counter::new();
 
-#[metric(name = "metric", metadata = { instance = "a"}, formatter = &custom_formatter)]
+#[metric(name = "metric", metadata = { instance = "a"}, formatter = custom_formatter)]
 static METRIC_A: Counter = Counter::new();
 
-#[metric(name = "metric", metadata = { instance = "b"}, formatter = &custom_formatter)]
+#[metric(name = "metric", metadata = { instance = "b"}, formatter = custom_formatter)]
 static METRIC_B: Counter = Counter::new();
 
 #[test]

--- a/metriken/tests/formatter.rs
+++ b/metriken/tests/formatter.rs
@@ -1,0 +1,42 @@
+use metriken::*;
+
+fn custom_formatter(metric: &MetricEntry, format: Format) -> String {
+    match format {
+        Format::Simple => {
+            format!("{}_instance_{}", metric.name(), metric.metadata().get("instance").unwrap_or("unknown"))
+        },
+        _ => metriken::default_formatter(metric, format),
+    }
+}
+
+#[metric(name = "metric", metadata = { instance = "a"}, formatter = &custom_formatter)]
+static METRIC_A: Counter = Counter::new();
+
+#[metric(name = "metric", metadata = { instance = "b"}, formatter = &custom_formatter)]
+static METRIC_B: Counter = Counter::new();
+
+#[test]
+fn metric_name_as_expected() {
+    let metrics = metrics().static_metrics();
+    let metric = metrics //
+        .iter()
+        .find(|entry| entry.is(&METRIC_A))
+        .unwrap();
+
+    assert_eq!(metrics.len(), 2);
+    assert_eq!(metric.name(), "metric");
+    assert_eq!(metric.formatted(Format::Simple), "metric_instance_a");
+}
+
+#[test]
+fn metric_name_and_description_as_expected() {
+    let metrics = metrics().static_metrics();
+    let metric = metrics
+        .iter()
+        .find(|entry| entry.is(&METRIC_B))
+        .unwrap();
+
+    assert_eq!(metrics.len(), 2);
+    assert_eq!(metric.name(), "metric");
+    assert_eq!(metric.formatted(Format::Simple), "metric_instance_b");
+}


### PR DESCRIPTION
Wires up the formatter so that we can specify and use custom metric formatters for various exposition formats.
