### PR TITLE
chore(ringlog): use in-tree version of metriken

### DIFF
--- a/ringlog/Cargo.toml
+++ b/ringlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ringlog"
-version = "0.1.1"
+version = "0.1.2-alpha"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Brian Martin <brian@pelikan.io>"]
@@ -11,6 +11,6 @@ repository = "https://github.com/pelikan-io/rustcommon"
 [dependencies]
 ahash = "0.8.0"
 clocksource = { version = "0.6.0", path = "../clocksource" }
-metriken = { version = "0.1.1" }
+metriken = { version = "0.2.0-alpha", path = "../metriken" }
 log = { version = "0.4.17", features = ["std"] }
 mpmc = "0.1.6"

--- a/ringlog/src/lib.rs
+++ b/ringlog/src/lib.rs
@@ -57,49 +57,49 @@ use mpmc::Queue;
 
 pub(crate) type LogBuffer = Vec<u8>;
 
-use metriken::*;
+use metriken::{metric, Counter, Gauge};
 
-counter!(LOG_CREATE, "logging targets initialized");
-counter!(
-    LOG_CREATE_EX,
-    "number of exceptions while initializing logging targets"
-);
-counter!(LOG_DESTROY, "logging targets destroyed");
-gauge!(LOG_CURR, "current number of logging targets");
-counter!(
-    LOG_OPEN,
-    "number of logging destinations which have been opened"
-);
-counter!(
-    LOG_OPEN_EX,
-    "number of exceptions while opening logging destinations"
-);
-counter!(LOG_WRITE, "number of writes to all loging destinations");
-counter!(
-    LOG_WRITE_BYTE,
-    "number of bytes written to all logging destinations"
-);
-counter!(
-    LOG_WRITE_EX,
-    "number of exceptions while writing to logging destinations"
-);
-counter!(
-    LOG_SKIP,
-    "number of log messages skipped due to sampling policy"
-);
-counter!(
-    LOG_DROP,
-    "number of log messages dropped due to full queues"
-);
-counter!(LOG_DROP_BYTE, "number of bytes dropped due to full queues");
-counter!(
-    LOG_FLUSH,
-    "number of times logging destinations have been flushed"
-);
-counter!(
-    LOG_FLUSH_EX,
-    "number of exceptions while flushing logging destinations"
-);
+#[metric(name = "log_create", description = "logging targets initialized")]
+pub static LOG_CREATE: Counter = Counter::new();
+
+#[metric(name = "log_create_ex", description = "number of exceptions while initializing logging targets")]
+pub static LOG_CREATE_EX: Counter = Counter::new();
+
+#[metric(name = "log_destroy", description = "logging targets destroyed")]
+pub static LOG_DESTROY: Counter = Counter::new();
+
+#[metric(name = "log_curr", description = "current number of logging targets")]
+pub static LOG_CURR: Gauge = Gauge::new();
+
+#[metric(name = "log_open", description = "number of logging destinations which have been opened")]
+pub static LOG_OPEN: Counter = Counter::new();
+
+#[metric(name = "log_open_ex", description = "number of exceptions while opening logging destinations")]
+pub static LOG_OPEN_EX: Counter = Counter::new();
+
+#[metric(name = "log_write", description = "number of writes to all logging destinations")]
+pub static LOG_WRITE: Counter = Counter::new();
+
+#[metric(name = "log_write_byte", description = "number of bytes written to all logging destinations")]
+pub static LOG_WRITE_BYTE: Counter = Counter::new();
+
+#[metric(name = "log_write_ex", description = "number of exceptions while writing to logging destinations")]
+pub static LOG_WRITE_EX: Counter = Counter::new();
+
+#[metric(name = "log_skip", description = "number of log messages skipped due to sampling policy")]
+pub static LOG_SKIP: Counter = Counter::new();
+
+#[metric(name = "log_drop", description = "number of log messages dropped due to full queues")]
+pub static LOG_DROP: Counter = Counter::new();
+
+#[metric(name = "log_drop_byte", description = "number of bytes dropped due to full queues")]
+pub static LOG_DROP_BYTE: Counter = Counter::new();
+
+#[metric(name = "log_flush", description = "number of times logging destinations have been flushed")]
+pub static LOG_FLUSH: Counter = Counter::new();
+
+#[metric(name = "log_flush_ex", description = "number of times logging destinations have been flushed")]
+pub static LOG_FLUSH_EX: Counter = Counter::new();
 
 /// A type which implements an asynchronous logging backend.
 pub struct RingLog {

--- a/ringlog/src/lib.rs
+++ b/ringlog/src/lib.rs
@@ -62,7 +62,10 @@ use metriken::{metric, Counter, Gauge};
 #[metric(name = "log_create", description = "logging targets initialized")]
 pub static LOG_CREATE: Counter = Counter::new();
 
-#[metric(name = "log_create_ex", description = "number of exceptions while initializing logging targets")]
+#[metric(
+    name = "log_create_ex",
+    description = "number of exceptions while initializing logging targets"
+)]
 pub static LOG_CREATE_EX: Counter = Counter::new();
 
 #[metric(name = "log_destroy", description = "logging targets destroyed")]
@@ -71,34 +74,64 @@ pub static LOG_DESTROY: Counter = Counter::new();
 #[metric(name = "log_curr", description = "current number of logging targets")]
 pub static LOG_CURR: Gauge = Gauge::new();
 
-#[metric(name = "log_open", description = "number of logging destinations which have been opened")]
+#[metric(
+    name = "log_open",
+    description = "number of logging destinations which have been opened"
+)]
 pub static LOG_OPEN: Counter = Counter::new();
 
-#[metric(name = "log_open_ex", description = "number of exceptions while opening logging destinations")]
+#[metric(
+    name = "log_open_ex",
+    description = "number of exceptions while opening logging destinations"
+)]
 pub static LOG_OPEN_EX: Counter = Counter::new();
 
-#[metric(name = "log_write", description = "number of writes to all logging destinations")]
+#[metric(
+    name = "log_write",
+    description = "number of writes to all logging destinations"
+)]
 pub static LOG_WRITE: Counter = Counter::new();
 
-#[metric(name = "log_write_byte", description = "number of bytes written to all logging destinations")]
+#[metric(
+    name = "log_write_byte",
+    description = "number of bytes written to all logging destinations"
+)]
 pub static LOG_WRITE_BYTE: Counter = Counter::new();
 
-#[metric(name = "log_write_ex", description = "number of exceptions while writing to logging destinations")]
+#[metric(
+    name = "log_write_ex",
+    description = "number of exceptions while writing to logging destinations"
+)]
 pub static LOG_WRITE_EX: Counter = Counter::new();
 
-#[metric(name = "log_skip", description = "number of log messages skipped due to sampling policy")]
+#[metric(
+    name = "log_skip",
+    description = "number of log messages skipped due to sampling policy"
+)]
 pub static LOG_SKIP: Counter = Counter::new();
 
-#[metric(name = "log_drop", description = "number of log messages dropped due to full queues")]
+#[metric(
+    name = "log_drop",
+    description = "number of log messages dropped due to full queues"
+)]
 pub static LOG_DROP: Counter = Counter::new();
 
-#[metric(name = "log_drop_byte", description = "number of bytes dropped due to full queues")]
+#[metric(
+    name = "log_drop_byte",
+    description = "number of bytes dropped due to full queues"
+)]
 pub static LOG_DROP_BYTE: Counter = Counter::new();
 
-#[metric(name = "log_flush", description = "number of times logging destinations have been flushed")]
+#[metric(
+    name = "log_flush",
+    description = "number of times logging destinations have been flushed"
+)]
 pub static LOG_FLUSH: Counter = Counter::new();
 
-#[metric(name = "log_flush_ex", description = "number of times logging destinations have been flushed")]
+#[metric(
+    name = "log_flush_ex",
+    description = "number of times logging destinations have been flushed"
+)]
 pub static LOG_FLUSH_EX: Counter = Counter::new();
 
 /// A type which implements an asynchronous logging backend.


### PR DESCRIPTION
Updates ringlog to use the in-tree version of metriken.
