### PR TITLE
fix(metriken): allow iteration over heatmap

### DIFF
--- a/heatmap/Cargo.toml
+++ b/heatmap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heatmap"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/heatmap/src/lib.rs
+++ b/heatmap/src/lib.rs
@@ -81,7 +81,7 @@ mod heatmap;
 use clocksource::Nanoseconds;
 use core::sync::atomic::AtomicU64;
 
-pub use self::heatmap::Heatmap;
+pub use self::heatmap::{Heatmap, Iter};
 pub use error::Error;
 
 pub type Instant = clocksource::Instant<Nanoseconds<u64>>;

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = [
 	"Brian Martin <brian@iop.systems>",
@@ -14,7 +14,7 @@ repository = "https://github.com/pelikan-io/rustcommon"
 [dependencies]
 metriken-derive = { version = "0.2.0", path = "./derive" }
 histogram = { version = "0.7.3", path = "../histogram" }
-heatmap = { version = "0.7.5", path = "../heatmap" }
+heatmap = { version = "0.7.6", path = "../heatmap" }
 
 linkme = "0.3.3"
 once_cell = "1.14.0"

--- a/metriken/src/heatmap.rs
+++ b/metriken/src/heatmap.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use heatmap::Instant;
 
+pub use ::heatmap::Iter as HeatmapIter;
 pub use ::heatmap::Error as HeatmapError;
 pub use ::histogram::Bucket;
 
@@ -80,6 +81,10 @@ impl Heatmap {
     /// Increments a time-value pair by some count.
     pub fn add(&self, time: Instant, value: u64, count: u32) -> Result<(), HeatmapError> {
         self.get_or_init().increment(time, value, count)
+    }
+
+    pub fn iter(&self) -> Option<HeatmapIter> {
+        self.inner.get().map(|heatmap| heatmap.iter())
     }
 
     fn get_or_init(&self) -> &::heatmap::Heatmap {

--- a/metriken/src/heatmap.rs
+++ b/metriken/src/heatmap.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use heatmap::Instant;
 
-pub use ::heatmap::Iter as HeatmapIter;
 pub use ::heatmap::Error as HeatmapError;
+pub use ::heatmap::Iter as HeatmapIter;
 pub use ::histogram::Bucket;
 
 /// A heatmap holds counts for quantized values across a period of time. It can


### PR DESCRIPTION
Fix to allow iterating over the heatmap.
