### PR TITLE
histogram: add compact serializable representation

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -9,10 +9,13 @@ homepage = "https://github.com/pelikan-io/rustcommon/histogram"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
+serde = "1.0.144"
+serde_derive = "1.0.144"
 thiserror = "1.0.38"
 
 [dev-dependencies]
 criterion = "0.4.0"
+itertools = "0.11.0"
 
 [[bench]]
 name = "bench"

--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -9,13 +9,15 @@ homepage = "https://github.com/pelikan-io/rustcommon/histogram"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
-serde = "1.0.144"
-serde_derive = "1.0.144"
+serde = { version = "1.0.180", features = ["derive"], optional = true }
 thiserror = "1.0.38"
 
 [dev-dependencies]
 criterion = "0.4.0"
 itertools = "0.11.0"
+
+[features]
+serde-serialize = ["serde"]
 
 [[bench]]
 name = "bench"

--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/pelikan-io/rustcommon/histogram"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
-serde = { version = "1.0.180", features = ["derive"], optional = true }
+serde = { version = "1.0.144", features = ["derive"], optional = true }
 thiserror = "1.0.38"
 
 [dev-dependencies]
@@ -17,6 +17,7 @@ criterion = "0.4.0"
 itertools = "0.11.0"
 
 [features]
+default = ["serde-serialize"]
 serde-serialize = ["serde"]
 
 [[bench]]

--- a/histogram/src/bucket.rs
+++ b/histogram/src/bucket.rs
@@ -4,7 +4,7 @@
 
 /// A `Bucket` represents a discrete range of values and the sum of recorded
 /// counts within this range.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct Bucket {
     pub(crate) low: u64,
     pub(crate) high: u64,

--- a/histogram/src/compact.rs
+++ b/histogram/src/compact.rs
@@ -1,0 +1,60 @@
+use serde_derive::{Deserialize, Serialize};
+
+use crate::histogram::Histogram;
+
+/// A `CompactHistogram` is a sparse, columnar representation of the
+/// Histogram. It is significantly smaller than a regular Histogram
+/// when a large number of buckets are zero, which is a frequent
+/// occurence; consequently it is used as the serialization format
+/// of the Histogram. It stores an individual vector for each field
+/// of non-zero buckets. Assuming index[0] = n, (index[0], count[0])
+/// corresponds to the nth bucket.
+#[derive(Serialize, Deserialize)]
+pub struct CompactHistogram {
+    /// parameters representing the resolution and the range of
+    /// the histogram tracking request latencies
+    pub m: u32,
+    pub r: u32,
+    pub n: u32,
+    /// indices for the non-zero buckets in the histogram
+    pub index: Vec<usize>,
+    /// histogram bucket counts corresponding to the indices
+    pub count: Vec<u32>,
+}
+
+impl From<&Histogram> for CompactHistogram {
+    fn from(histogram: &Histogram) -> Self {
+        let mut index = Vec::new();
+        let mut count = Vec::new();
+
+        for (i, bucket) in histogram
+            .into_iter()
+            .enumerate()
+            .filter(|(_i, bucket)| bucket.count() != 0)
+        {
+            index.push(i);
+            count.push(bucket.count());
+        }
+
+        let p = histogram.parameters();
+        Self {
+            m: p.0,
+            r: p.1,
+            n: p.2,
+            index,
+            count,
+        }
+    }
+}
+
+impl CompactHistogram {
+    pub fn new() -> Self {
+        return Self {
+            m: 0,
+            r: 0,
+            n: 0,
+            index: Vec::new(),
+            count: Vec::new(),
+        };
+    }
+}

--- a/histogram/src/compact.rs
+++ b/histogram/src/compact.rs
@@ -1,4 +1,4 @@
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::histogram::Histogram;
 

--- a/histogram/src/compact.rs
+++ b/histogram/src/compact.rs
@@ -9,7 +9,7 @@ use crate::histogram::Histogram;
 /// of the Histogram. It stores an individual vector for each field
 /// of non-zero buckets. Assuming index[0] = n, (index[0], count[0])
 /// corresponds to the nth bucket.
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct CompactHistogram {
     /// parameters representing the resolution and the range of
     /// the histogram tracking request latencies
@@ -20,24 +20,6 @@ pub struct CompactHistogram {
     pub index: Vec<usize>,
     /// histogram bucket counts corresponding to the indices
     pub count: Vec<u32>,
-}
-
-impl CompactHistogram {
-    pub fn new() -> Self {
-        Self {
-            m: 0,
-            r: 0,
-            n: 0,
-            index: Vec::new(),
-            count: Vec::new(),
-        }
-    }
-}
-
-impl Default for CompactHistogram {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl From<&Histogram> for CompactHistogram {

--- a/histogram/src/compact.rs
+++ b/histogram/src/compact.rs
@@ -22,6 +22,24 @@ pub struct CompactHistogram {
     pub count: Vec<u32>,
 }
 
+impl CompactHistogram {
+    pub fn new() -> Self {
+        Self {
+            m: 0,
+            r: 0,
+            n: 0,
+            index: Vec::new(),
+            count: Vec::new(),
+        }
+    }
+}
+
+impl Default for CompactHistogram {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<&Histogram> for CompactHistogram {
     fn from(histogram: &Histogram) -> Self {
         let mut index = Vec::new();
@@ -44,17 +62,5 @@ impl From<&Histogram> for CompactHistogram {
             index,
             count,
         }
-    }
-}
-
-impl CompactHistogram {
-    pub fn new() -> Self {
-        return Self {
-            m: 0,
-            r: 0,
-            n: 0,
-            index: Vec::new(),
-            count: Vec::new(),
-        };
     }
 }

--- a/histogram/src/histogram.rs
+++ b/histogram/src/histogram.rs
@@ -466,9 +466,12 @@ impl TryFrom<&CompactHistogram> for Histogram {
 
     fn try_from(h: &CompactHistogram) -> Result<Self, Self::Error> {
         let histogram = Histogram::new(h.m, h.r, h.n)?;
+        let nbuckets = histogram.buckets();
         for (i, bucket_id) in h.index.iter().enumerate() {
-            let v = h.count[i];
-            histogram.buckets[*bucket_id].store(v, Ordering::Relaxed);
+            if *bucket_id >= nbuckets {
+                return Err(Error::OutOfRange);
+            }
+            histogram.buckets[*bucket_id].store(h.count[i], Ordering::Relaxed);
         }
         Ok(histogram)
     }

--- a/histogram/src/histogram.rs
+++ b/histogram/src/histogram.rs
@@ -461,6 +461,7 @@ impl Clone for Histogram {
     }
 }
 
+#[cfg(feature = "serde-serialize")]
 impl TryFrom<&CompactHistogram> for Histogram {
     type Error = error::Error;
 

--- a/histogram/src/histogram.rs
+++ b/histogram/src/histogram.rs
@@ -461,6 +461,19 @@ impl Clone for Histogram {
     }
 }
 
+impl TryFrom<&CompactHistogram> for Histogram {
+    type Error = error::Error;
+
+    fn try_from(h: &CompactHistogram) -> Result<Self, Self::Error> {
+        let histogram = Histogram::new(h.m, h.r, h.n)?;
+        for (i, bucket_id) in h.index.iter().enumerate() {
+            let v = h.count[i];
+            histogram.buckets[*bucket_id].store(v, Ordering::Relaxed);
+        }
+        Ok(histogram)
+    }
+}
+
 /// An iterator that allows walking through the `Bucket`s within a `Histogram`.
 pub struct HistogramIter<'a> {
     current: usize,

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn compact_histogram() {
-        let h = CompactHistogram::new();
+        let h = CompactHistogram::default();
         assert_eq!(h.m, 0);
         assert_eq!(h.r, 0);
         assert_eq!(h.n, 0);

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -3,12 +3,14 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 mod bucket;
+mod compact;
 mod error;
 mod histogram;
 mod percentile;
 
 pub use self::histogram::{Builder, Histogram};
 pub use bucket::Bucket;
+pub use compact::CompactHistogram;
 pub use error::Error;
 pub use percentile::Percentile;
 
@@ -17,7 +19,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_builder() {
+    fn builder() {
         let h = Histogram::builder().build().unwrap();
         let p = h.parameters();
 
@@ -27,7 +29,7 @@ mod tests {
     }
 
     #[test]
-    fn test_min_resolution() {
+    fn min_resolution() {
         let h = Histogram::builder().min_resolution(10).build().unwrap();
         assert_eq!(h.parameters().0, 3);
 
@@ -145,7 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn test_increment_and_decrement() {
+    fn increment_and_decrement() {
         let histogram = Histogram::builder().build().unwrap();
         assert_eq!(
             histogram.percentile(0.0).map(|b| b.count()),
@@ -160,5 +162,41 @@ mod tests {
             histogram.percentile(0.0).map(|b| b.count()),
             Err(Error::Empty)
         );
+    }
+
+    #[test]
+    fn compact_histogram() {
+        let h = CompactHistogram::new();
+        assert_eq!(h.m, 0);
+        assert_eq!(h.r, 0);
+        assert_eq!(h.n, 0);
+        assert_eq!(&h.index, &[]);
+        assert_eq!(&h.count, &[]);
+
+        assert_eq!(Histogram::try_from(&h).is_err(), true);
+    }
+
+    #[test]
+    fn hydrate_and_dehydrate() {
+        let histogram = Histogram::new(0, 5, 10).unwrap();
+
+        for v in (1..1024).step_by(128) {
+            assert!(histogram.increment(v, 1).is_ok());
+        }
+
+        let h = CompactHistogram::from(&histogram);
+        assert_eq!(h.m, 0);
+        assert_eq!(h.r, 5);
+        assert_eq!(h.n, 10);
+        assert_eq!(&h.index, &[1, 64, 80, 88, 96, 100, 104, 108]);
+        assert_eq!(&h.count, &[1, 1, 1, 1, 1, 1, 1, 1]);
+
+        let rehydrated = Histogram::try_from(&h).unwrap();
+        assert_eq!(rehydrated.parameters(), histogram.parameters());
+        assert_eq!(rehydrated.buckets(), histogram.buckets());
+        assert!(itertools::equal(
+            rehydrated.into_iter(),
+            histogram.into_iter()
+        ));
     }
 }

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -3,6 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 mod bucket;
+#[cfg(feature = "serde-serialize")]
 mod compact;
 mod error;
 mod histogram;
@@ -10,6 +11,7 @@ mod percentile;
 
 pub use self::histogram::{Builder, Histogram};
 pub use bucket::Bucket;
+#[cfg(feature = "serde-serialize")]
 pub use compact::CompactHistogram;
 pub use error::Error;
 pub use percentile::Percentile;
@@ -164,6 +166,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "serde-serialize")]
     #[test]
     fn compact_histogram() {
         let h = CompactHistogram::default();
@@ -176,6 +179,7 @@ mod tests {
         assert!(Histogram::try_from(&h).is_err());
     }
 
+    #[cfg(feature = "serde-serialize")]
     #[test]
     fn hydrate_and_dehydrate() {
         let histogram = Histogram::new(0, 5, 10).unwrap();

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -173,7 +173,7 @@ mod tests {
         assert_eq!(&h.index, &[]);
         assert_eq!(&h.count, &[]);
 
-        assert_eq!(Histogram::try_from(&h).is_err(), true);
+        assert!(Histogram::try_from(&h).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Add a compact (sparse and columnar) serializable representation of
the histogram for storage and transfer, along with to and fro conversion
functions.