### PR TITLE
metriken: documentation comment updates

### DIFF
--- a/metriken/derive/src/lib.rs
+++ b/metriken/derive/src/lib.rs
@@ -11,13 +11,13 @@ mod metric;
 ///
 /// Note that this will change the type of the generated static to be
 /// `MetricInstance<MetricTy>`. It implements both [`Deref`] and [`DerefMut`]
-/// so it can be used much the same as a normal static.  
+/// so it can be used much the same as a normal static.
 ///
 /// # Parameters
-/// - (optional) `crate`: The path to the `rustcommon_metrics` crate. This
-///   allows the `metric` macro to be used within other macros that get exported
-///   to third-party crates which may not have added `rustcommon_metrics` to
-///   their Cargo.toml.
+/// - (optional) `crate`: The path to the `metriken` crate. This allows the
+///   `metric` macro to be used within other macros that get exported to
+///   third-party crates which may not have added `metriken` to their
+///   Cargo.toml.
 /// - (optional) `formatter`: A function to be used to determine the output name
 ///   for this metric.
 ///

--- a/metriken/src/formatter.rs
+++ b/metriken/src/formatter.rs
@@ -21,6 +21,8 @@ pub enum Format {
     Prometheus,
 }
 
+/// The default formatter supports Prometheus-style exposition, and otherwise
+/// simply prints the metric name.
 pub fn default_formatter(metric: &MetricEntry, format: Format) -> String {
     match format {
         Format::Prometheus => {


### PR DESCRIPTION
1. found a place that is out of sync with the crate name change;
2. fixed a Metriken function that's missing description.