### PR TITLE
histogram: allow downsampling

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = "1.0.47"
 
 [dev-dependencies]
 criterion = "0.5.1"
+rand = "0.8.5"
 
 [[bench]]
 name = "histogram"

--- a/histogram/src/config.rs
+++ b/histogram/src/config.rs
@@ -130,9 +130,15 @@ impl Config {
         self.max_value_power
     }
 
-    /// Returns the relative error (in percentage) of this configuration.
+    /// Returns the relative error (in percentage) of this configuration. This
+    /// only applies to the logarithmic bins of the histogram (linear bins have
+    /// a width of 1 and no error). For histograms with no logarithmic bins,
+    /// error for the entire histogram is zero.
     pub fn error(&self) -> f64 {
-        100.0 / 2_u64.pow(self.grouping_power as u32) as f64
+        match self.grouping_power == self.max_value_power - 1 {
+            true => 0.0,
+            false => 100.0 / 2_u64.pow(self.grouping_power as u32) as f64,
+        }
     }
 
     /// Return the total number of buckets needed for this config.

--- a/histogram/src/config.rs
+++ b/histogram/src/config.rs
@@ -130,6 +130,11 @@ impl Config {
         self.max_value_power
     }
 
+    /// Returns the relative error (in percentage) of this configuration.
+    pub fn error(&self) -> f64 {
+        100.0 / 2_u64.pow(self.grouping_power as u32) as f64
+    }
+
     /// Return the total number of buckets needed for this config.
     pub const fn total_buckets(&self) -> usize {
         (self.lower_bin_count + self.upper_bin_count) as usize

--- a/histogram/src/config.rs
+++ b/histogram/src/config.rs
@@ -165,7 +165,7 @@ impl Config {
     }
 
     /// Convert a bucket index to a lower bound.
-    fn index_to_lower_bound(&self, index: usize) -> u64 {
+    pub(crate) fn index_to_lower_bound(&self, index: usize) -> u64 {
         let g = index as u64 >> self.grouping_power;
         let h = index as u64 - g * (1 << self.grouping_power);
 
@@ -177,7 +177,7 @@ impl Config {
     }
 
     /// Convert a bucket index to a upper inclusive bound.
-    fn index_to_upper_bound(&self, index: usize) -> u64 {
+    pub(crate) fn index_to_upper_bound(&self, index: usize) -> u64 {
         if index as u32 == self.lower_bin_count + self.upper_bin_count - 1 {
             return self.max;
         }

--- a/histogram/src/errors.rs
+++ b/histogram/src/errors.rs
@@ -8,6 +8,8 @@ pub enum BuildError {
     MaxPowerTooHigh,
     #[error("max power is too low, check that a + b < n")]
     MaxPowerTooLow,
+    #[error("grouping power is too low, must be > 0")]
+    GroupingPowerTooLow,
     #[error("boxed slice length does not match the config")]
     FromRawWrongLength,
     #[error("sliding window interval cannot be greater than 1 hour")]

--- a/histogram/src/errors.rs
+++ b/histogram/src/errors.rs
@@ -8,8 +8,6 @@ pub enum BuildError {
     MaxPowerTooHigh,
     #[error("max power is too low, check that a + b < n")]
     MaxPowerTooLow,
-    #[error("grouping power is too low, must be > 0")]
-    GroupingPowerTooLow,
     #[error("boxed slice length does not match the config")]
     FromRawWrongLength,
     #[error("sliding window interval cannot be greater than 1 hour")]
@@ -36,4 +34,6 @@ pub enum Error {
     IncompatibleTimeRange,
     #[error("an overflow occurred")]
     Overflow,
+    #[error("an unknown error occurred")]
+    Unknown,
 }

--- a/histogram/src/snapshot.rs
+++ b/histogram/src/snapshot.rs
@@ -1,4 +1,4 @@
-use crate::{Bucket, BuildError, Config, Error, Histogram};
+use crate::{Bucket, Config, Error, Histogram};
 use std::time::SystemTime;
 
 /// A snapshot of a histogram across a time range.
@@ -37,7 +37,7 @@ impl Snapshot {
     /// The new histogram is smaller but with greater relative error. The
     /// reduction factor should be smaller than the histogram's existing
     /// grouping power.
-    pub fn downsample(&self, factor: u8) -> Result<Snapshot, BuildError> {
+    pub fn downsample(&self, factor: u8) -> Result<Snapshot, Error> {
         let histogram = self.histogram.downsample(factor)?;
 
         Ok(Self {

--- a/histogram/src/snapshot.rs
+++ b/histogram/src/snapshot.rs
@@ -1,4 +1,4 @@
-use crate::{Bucket, Config, Error, Histogram};
+use crate::{Bucket, BuildError, Config, Error, Histogram};
 use std::time::SystemTime;
 
 /// A snapshot of a histogram across a time range.
@@ -30,6 +30,20 @@ impl Snapshot {
     /// example, the 50th percentile (median) can be found using `50.0`.
     pub fn percentile(&self, percentile: f64) -> Result<Bucket, Error> {
         self.histogram.percentile(percentile)
+    }
+
+    /// Returns a new downsampled histogram with a reduced grouping power.
+    ///
+    /// The new histogram is smaller but with greater relative error. The
+    /// reduction factor should be smaller than the histogram's existing
+    /// grouping power.
+    pub fn downsample(&self, factor: u8) -> Result<Snapshot, BuildError> {
+        let histogram = self.histogram.downsample(factor)?;
+
+        Ok(Self {
+            end: self.end,
+            histogram,
+        })
     }
 
     /// Merges two snapshots which cover the same time range.

--- a/histogram/src/standard.rs
+++ b/histogram/src/standard.rs
@@ -130,6 +130,41 @@ impl Histogram {
         }
     }
 
+    /// Returns a new histogram with a reduced grouping power.
+    ///
+    /// The specified factor determines how much the grouping power is reduced
+    /// by and should be smaller than the histogram's existing grouping power.
+    /// Every step of grouping power halves the total number of buckets (and
+    /// hence total size of thie histogram), while doubling the error.
+    ///
+    /// This works by iterating over every bucket in the existing histogram
+    /// and inserting the contained values into the new histogram. Since we
+    /// do not know the exact values of the data points (only that they lie
+    /// within the bucket's range), we pick a pessimistic high value.
+    pub fn downsample(&self, factor: u8) -> Result<Histogram, BuildError> {
+        let grouping_power = self.config.grouping_power();
+
+        if grouping_power <= factor {
+            return Err(BuildError::GroupingPowerTooLow);
+        }
+
+        let mut histogram = Histogram::new(grouping_power - factor, self.config.max_value_power())?;
+
+        for (i, n) in self.as_slice().iter().enumerate() {
+            let bucket_range = self.config.index_to_range(i);
+            let val = (*bucket_range.start() + *bucket_range.end()) / 2;
+
+            if histogram.add(val, *n).is_err() {
+                // Fails because of overflow: too small a grouping power means
+                // too many buckets of the original histogram map to the same
+                // bucket in the new one.
+                return Err(BuildError::GroupingPowerTooLow);
+            }
+        }
+
+        Ok(histogram)
+    }
+
     /// Adds the other histogram to this histogram and returns the result as a
     /// new histogram.
     ///
@@ -250,6 +285,7 @@ impl<'a> Iterator for Iter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::Rng;
 
     #[test]
     fn size() {
@@ -307,6 +343,48 @@ mod tests {
                 range: 1024..=1031,
             })
         );
+    }
+
+    #[test]
+    // Tests downsampling
+    fn downsample() {
+        let mut histogram = Histogram::new(8, 32).unwrap();
+        let mut vals: Vec<u64> = Vec::with_capacity(10000);
+        let mut rng = rand::thread_rng();
+
+        // Generate 10,000 values to store in a sorted array and a histogram
+        for _ in 0..10000 {
+            let v: u64 = rng.gen_range(1..2_u64.pow(histogram.config.max_value_power() as u32));
+            vals.push(v);
+            let _ = histogram.increment(v);
+        }
+        vals.sort();
+
+        // List of percentiles to query and validate
+        let mut percentiles: Vec<f64> = Vec::with_capacity(109);
+        for i in 20..99 {
+            percentiles.push(i as f64);
+        }
+        let mut tail = vec![
+            99.1, 99.2, 99.3, 99.4, 99.5, 99.6, 99.7, 99.8, 99.9, 99.99, 100.0,
+        ];
+        percentiles.append(&mut tail);
+
+        // Downsample and check the percentiles lie within error margin
+        for factor in 1..4 {
+            let error = histogram.config.error();
+
+            for p in &percentiles {
+                let v = vals[((*p * 100.0) as usize) - 1];
+
+                // Value and relative error from full histogram
+                let vhist = histogram.percentile(*p).unwrap().end();
+                let e = (v.abs_diff(vhist) as f64) * 100.0 / (v as f64);
+                assert!(e < error);
+            }
+
+            histogram = histogram.downsample(factor).unwrap();
+        }
     }
 
     // Return four histograms (three with identical configs and one with a

--- a/histogram/src/standard.rs
+++ b/histogram/src/standard.rs
@@ -142,7 +142,7 @@ impl Histogram {
     /// and inserting the contained values into the new histogram. While we
     /// do not know the exact values of the data points (only that they lie
     /// within the bucket's range), it does not matter since the bucket is
-    /// not split during downsampling any any value can be used.
+    /// not split during downsampling and any value can be used.
     pub fn downsample(&self, factor: u8) -> Result<Histogram, Error> {
         let grouping_power = self.config.grouping_power();
 

--- a/histogram/src/standard.rs
+++ b/histogram/src/standard.rs
@@ -139,9 +139,10 @@ impl Histogram {
     /// doubling the relative error.
     ///
     /// This works by iterating over every bucket in the existing histogram
-    /// and inserting the contained values into the new histogram. Since we
+    /// and inserting the contained values into the new histogram. While we
     /// do not know the exact values of the data points (only that they lie
-    /// within the bucket's range), we pick a pessimistic high value.
+    /// within the bucket's range), it does not matter since the bucket is
+    /// not split during downsampling any any value can be used.
     pub fn downsample(&self, factor: u8) -> Result<Histogram, Error> {
         let grouping_power = self.config.grouping_power();
 
@@ -157,8 +158,7 @@ impl Histogram {
         let mut histogram = histogram.unwrap();
 
         for (i, n) in self.as_slice().iter().enumerate() {
-            let bucket_range = self.config.index_to_range(i);
-            let val = (*bucket_range.start() + *bucket_range.end()) / 2;
+            let val = self.config.index_to_lower_bound(i);
             histogram.add(val, *n)?;
         }
 


### PR DESCRIPTION
Allow downsampling of the histogram and snapshot. This trades
space for increased relative error.