### PR TITLE
Resolved the issue below, as  reported by cargo clippy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver="2"
 members = [
     "awaken",
     "clocksource",


### PR DESCRIPTION
Problem

This clippy warning 

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

Solution

Just followed the solution suggested  in the warning 

Result
 
No clippy warnings.
