### PR TITLE
histogram: fix test for downsampling histograms

### DIFF
--- a/histogram/src/standard.rs
+++ b/histogram/src/standard.rs
@@ -365,7 +365,8 @@ mod tests {
         percentiles.append(&mut tail);
 
         // Downsample and check the percentiles lie within error margin
-        for factor in 1..4 {
+        let h = histogram.clone();
+        for factor in 1..7 {
             let error = histogram.config.error();
 
             for p in &percentiles {
@@ -377,7 +378,7 @@ mod tests {
                 assert!(e < error);
             }
 
-            histogram = histogram.downsample(factor).unwrap();
+            histogram = h.downsample(factor).unwrap();
         }
     }
 


### PR DESCRIPTION
The downsample() test uses both an incrementing factor for the
downsampling as well as a mutable reference as the baseline.
This makes the effective downsampling rate increase at a non-linear
rate (1, 3, 6, ..). Fix by cloning the histogram and using a non-mutable
reference as the baseline.