### PR TITLE
feat(histogram): expose histogram add functions

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Brian Martin <brian@pelikan.io>"]
 license = "MIT OR Apache-2.0"

--- a/histogram/src/standard.rs
+++ b/histogram/src/standard.rs
@@ -167,7 +167,7 @@ impl Histogram {
     ///
     /// An error is returned if the two histograms have incompatible parameters
     /// or if there is an overflow.
-    pub(crate) fn checked_add(&self, other: &Histogram) -> Result<Histogram, Error> {
+    pub fn checked_add(&self, other: &Histogram) -> Result<Histogram, Error> {
         if self.config != other.config {
             return Err(Error::IncompatibleParameters);
         }
@@ -185,7 +185,7 @@ impl Histogram {
     /// new histogram.
     ///
     /// An error is returned if the two histograms have incompatible parameters.
-    pub(crate) fn wrapping_add(&self, other: &Histogram) -> Result<Histogram, Error> {
+    pub fn wrapping_add(&self, other: &Histogram) -> Result<Histogram, Error> {
         if self.config != other.config {
             return Err(Error::IncompatibleParameters);
         }


### PR DESCRIPTION
Exposes the `Histogram::checked_add` and `wrapping_add` functions publicly.
