### PR TITLE
histogram: add sparse representation

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Brian Martin <brian@pelikan.io>"]
 license = "MIT OR Apache-2.0"

--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -9,11 +9,15 @@ homepage = "https://github.com/pelikan-io/rustcommon"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
+serde = { version = "1.0.144", features = ["derive"], optional = true }
 thiserror = "1.0.47"
 
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.5"
+
+[features]
+serde-serialize = ["serde"]
 
 [[bench]]
 name = "histogram"

--- a/histogram/src/config.rs
+++ b/histogram/src/config.rs
@@ -1,6 +1,9 @@
 use crate::Error;
 use core::ops::RangeInclusive;
 
+#[cfg(feature = "serde-serialize")]
+use serde::{Deserialize, Serialize};
+
 /// The configuration of a histogram which determines the bucketing strategy and
 /// therefore the relative error and memory utilization of a histogram.
 /// * `grouping_power` - controls the number of buckets that are used to span
@@ -53,6 +56,7 @@ use core::ops::RangeInclusive;
 /// * `max_value_power` must be in the range `0..=64`
 /// * `max_value_power` must be greater than `grouping_power
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct Config {
     max: u64,
     grouping_power: u8,

--- a/histogram/src/errors.rs
+++ b/histogram/src/errors.rs
@@ -18,6 +18,4 @@ pub enum Error {
     IncompatibleTimeRange,
     #[error("an overflow occurred")]
     Overflow,
-    #[error("unreachable code encountered")]
-    Unreachable,
 }

--- a/histogram/src/errors.rs
+++ b/histogram/src/errors.rs
@@ -8,6 +8,8 @@ pub enum Error {
     MaxPowerTooHigh,
     #[error("max power is too low, check that a + b < n")]
     MaxPowerTooLow,
+    #[error("histogram contains no observations")]
+    Empty,
     #[error("invalid percentile, must be in range 0.0..=100.0")]
     InvalidPercentile,
     #[error("the value is outside of the storable range")]
@@ -18,4 +20,6 @@ pub enum Error {
     IncompatibleTimeRange,
     #[error("an overflow occurred")]
     Overflow,
+    #[error("unreachable code encountered")]
+    Unreachable,
 }

--- a/histogram/src/errors.rs
+++ b/histogram/src/errors.rs
@@ -8,8 +8,6 @@ pub enum Error {
     MaxPowerTooHigh,
     #[error("max power is too low, check that a + b < n")]
     MaxPowerTooLow,
-    #[error("histogram contains no observations")]
-    Empty,
     #[error("invalid percentile, must be in range 0.0..=100.0")]
     InvalidPercentile,
     #[error("the value is outside of the storable range")]

--- a/histogram/src/lib.rs
+++ b/histogram/src/lib.rs
@@ -16,6 +16,7 @@ mod bucket;
 mod config;
 mod errors;
 mod snapshot;
+mod sparse;
 mod standard;
 
 pub use atomic::AtomicHistogram;
@@ -23,4 +24,5 @@ pub use bucket::Bucket;
 pub use config::Config;
 pub use errors::Error;
 pub use snapshot::Snapshot;
+pub use sparse::SparseHistogram;
 pub use standard::Histogram;

--- a/histogram/src/sparse.rs
+++ b/histogram/src/sparse.rs
@@ -29,12 +29,13 @@ impl SparseHistogram {
         }
     }
 
-    /// Merges two Histograms and returns the results in a new Histogram.
+    /// Adds the other histogram to this histogram and returns the result as a
+    /// new histogram.
     ///
-    /// Both histograms must have the same configuration parameters.
+    /// An error is returned if the two histograms have incompatible parameters.
     /// Buckets which have values in both histograms are allowed to wrap.
     #[allow(clippy::comparison_chain)]
-    pub fn merge(&self, h: &SparseHistogram) -> Result<SparseHistogram, Error> {
+    pub fn wrapping_add(&self, h: &SparseHistogram) -> Result<SparseHistogram, Error> {
         if self.config != h.config {
             return Err(Error::IncompatibleParameters);
         }
@@ -226,18 +227,18 @@ mod tests {
             count: Vec::new(),
         };
 
-        let h = h1.merge(&hdiff);
+        let h = h1.wrapping_add(&hdiff);
         assert_eq!(h, Err(Error::IncompatibleParameters));
 
-        let h = h1.merge(&h2).unwrap();
+        let h = h1.wrapping_add(&h2).unwrap();
         assert_eq!(h.index, vec![1, 3, 5]);
         assert_eq!(h.count, vec![6, 12, 7]);
 
-        let h = h2.merge(&h3).unwrap();
+        let h = h2.wrapping_add(&h3).unwrap();
         assert_eq!(h.index, vec![2, 3, 4, 11]);
         assert_eq!(h.count, vec![5, 7, 3, 15]);
 
-        let h = h1.merge(&h3).unwrap();
+        let h = h1.wrapping_add(&h3).unwrap();
         assert_eq!(h.index, vec![1, 2, 3, 4, 5, 11]);
         assert_eq!(h.count, vec![6, 5, 19, 3, 7, 15]);
     }

--- a/histogram/src/sparse.rs
+++ b/histogram/src/sparse.rs
@@ -9,7 +9,7 @@ use crate::{Bucket, Config, Error, Histogram, Snapshot};
 /// occurence. It stores an individual vector for each field
 /// of non-zero buckets. Assuming index[0] = n, (index[0], count[0])
 /// corresponds to the nth bucket.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct SparseHistogram {
     /// parameters representing the resolution and the range of

--- a/histogram/src/sparse.rs
+++ b/histogram/src/sparse.rs
@@ -72,8 +72,8 @@ impl SparseHistogram {
 
         // Fill remaining values, if any, from the right histogram
         if j < h.index.len() {
-            histogram.index.extend(&h.index[i..h.index.len()]);
-            histogram.count.extend(&h.count[i..h.count.len()]);
+            histogram.index.extend(&h.index[j..h.index.len()]);
+            histogram.count.extend(&h.count[j..h.count.len()]);
         }
 
         Ok(histogram)
@@ -217,8 +217,8 @@ mod tests {
 
         let h3 = SparseHistogram {
             config,
-            index: vec![2, 3, 4, 11],
-            count: vec![5, 7, 3, 15],
+            index: vec![2, 3, 6, 11, 13],
+            count: vec![5, 7, 3, 15, 6],
         };
 
         let hdiff = SparseHistogram {
@@ -235,12 +235,12 @@ mod tests {
         assert_eq!(h.count, vec![6, 12, 7]);
 
         let h = h2.wrapping_add(&h3).unwrap();
-        assert_eq!(h.index, vec![2, 3, 4, 11]);
-        assert_eq!(h.count, vec![5, 7, 3, 15]);
+        assert_eq!(h.index, vec![2, 3, 6, 11, 13]);
+        assert_eq!(h.count, vec![5, 7, 3, 15, 6]);
 
         let h = h1.wrapping_add(&h3).unwrap();
-        assert_eq!(h.index, vec![1, 2, 3, 4, 5, 11]);
-        assert_eq!(h.count, vec![6, 5, 19, 3, 7, 15]);
+        assert_eq!(h.index, vec![1, 2, 3, 5, 6, 11, 13]);
+        assert_eq!(h.count, vec![6, 5, 19, 7, 3, 15, 6]);
     }
 
     #[test]

--- a/histogram/src/sparse.rs
+++ b/histogram/src/sparse.rs
@@ -1,0 +1,147 @@
+// use serde::{Deserialize, Serialize};
+
+use crate::{Error, Snapshot};
+
+/// This histogram is a sparse, columnar representation of the regular
+/// Histogram. It is significantly smaller than a regular Histogram
+/// when a large number of buckets are zero, which is a frequent
+/// occurence. It stores an individual vector for each field
+/// of non-zero buckets. Assuming index[0] = n, (index[0], count[0])
+/// corresponds to the nth bucket.
+// #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq)]
+pub struct SparseHistogram {
+    /// parameters representing the resolution and the range of
+    /// the histogram tracking request latencies
+    pub grouping_power: u8,
+    pub max_value_power: u8,
+    /// indices for the non-zero buckets in the histogram
+    pub index: Vec<usize>,
+    /// histogram bucket counts corresponding to the indices
+    pub count: Vec<u64>,
+}
+
+impl SparseHistogram {
+    fn add_bucket(&mut self, idx: usize, n: u64) {
+        self.index.push(idx);
+        self.count.push(n);
+    }
+
+    /// Merges two Histograms and returns the results in a new Histogram.
+    ///
+    /// Both histograms must have the same configuration parameters.
+    /// Buckets which have values in both histograms are allowed to wrap.
+    #[allow(clippy::comparison_chain)]
+    pub fn merge(&self, h: &SparseHistogram) -> Result<SparseHistogram, Error> {
+        if self.grouping_power != h.grouping_power || self.max_value_power != h.max_value_power {
+            return Err(Error::IncompatibleParameters);
+        }
+
+        let mut histogram = SparseHistogram {
+            grouping_power: self.grouping_power,
+            max_value_power: self.max_value_power,
+            index: Vec::new(),
+            count: Vec::new(),
+        };
+
+        // Sort and merge buckets from both histograms
+        let (mut i, mut j) = (0, 0);
+        while i < self.index.len() && j < h.index.len() {
+            let (k1, v1) = (self.index[i], self.count[i]);
+            let (k2, v2) = (h.index[j], h.count[j]);
+
+            if k1 == k2 {
+                histogram.add_bucket(k1, v1 + v2);
+                (i, j) = (i + 1, j + 1);
+            } else if k1 < k2 {
+                histogram.add_bucket(k1, v1);
+                i += 1;
+            } else {
+                histogram.add_bucket(k2, v2);
+                j += 1;
+            }
+        }
+
+        // Fill remaining values, if any, from the left histogram
+        if i < self.index.len() {
+            histogram.index.extend(&self.index[i..self.index.len()]);
+            histogram.count.extend(&self.count[i..self.count.len()]);
+        }
+
+        // Fill remaining values, if any, from the right histogram
+        if j < h.index.len() {
+            histogram.index.extend(&h.index[i..h.index.len()]);
+            histogram.count.extend(&h.count[i..h.count.len()]);
+        }
+
+        Ok(histogram)
+    }
+}
+
+impl From<&Snapshot> for SparseHistogram {
+    fn from(snapshot: &Snapshot) -> Self {
+        let mut index = Vec::new();
+        let mut count = Vec::new();
+
+        for (i, bucket) in snapshot
+            .into_iter()
+            .enumerate()
+            .filter(|(_i, bucket)| bucket.count() != 0)
+        {
+            index.push(i);
+            count.push(bucket.count());
+        }
+
+        let config = snapshot.config();
+        Self {
+            grouping_power: config.grouping_power(),
+            max_value_power: config.max_value_power(),
+            index,
+            count,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge() {
+        let h1 = SparseHistogram {
+            grouping_power: 8,
+            max_value_power: 32,
+            index: vec![1, 3, 5],
+            count: vec![6, 12, 7],
+        };
+
+        let h2 = SparseHistogram {
+            grouping_power: 8,
+            max_value_power: 32,
+            index: Vec::new(),
+            count: Vec::new(),
+        };
+
+        let h3 = SparseHistogram {
+            grouping_power: 8,
+            max_value_power: 32,
+            index: vec![2, 3, 4, 11],
+            count: vec![5, 7, 3, 15],
+        };
+
+        let h = h1.merge(&SparseHistogram::default());
+        assert_eq!(h, Err(Error::IncompatibleParameters));
+
+        let h = h1.merge(&h2).unwrap();
+        assert_eq!(h.index, vec![1, 3, 5]);
+        assert_eq!(h.count, vec![6, 12, 7]);
+
+        let h = h2.merge(&h3).unwrap();
+        assert_eq!(h.index, vec![2, 3, 4, 11]);
+        assert_eq!(h.count, vec![5, 7, 3, 15]);
+
+        let h = h1.merge(&h3).unwrap();
+        assert_eq!(h.index, vec![1, 2, 3, 4, 5, 11]);
+        assert_eq!(h.count, vec![6, 5, 19, 3, 7, 15]);
+    }
+}

--- a/histogram/src/sparse.rs
+++ b/histogram/src/sparse.rs
@@ -101,8 +101,12 @@ impl SparseHistogram {
             }
         }
 
-        // should be unreachable
-        Err(Error::Unreachable)
+        // should never be reached; return highest bucket if not found
+        let last_idx = self.index.len() - 1;
+        Ok(Bucket {
+            count: self.count[last_idx],
+            range: self.config.index_to_range(self.index[last_idx]),
+        })
     }
 
     /// Returns a new histogram with a reduced grouping power. The specified

--- a/histogram/src/sparse.rs
+++ b/histogram/src/sparse.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde-serialize")]
+use serde::{Deserialize, Serialize};
+
 use crate::{Bucket, Config, Error, Snapshot};
 
 /// This histogram is a sparse, columnar representation of the regular
@@ -7,6 +10,7 @@ use crate::{Bucket, Config, Error, Snapshot};
 /// of non-zero buckets. Assuming index[0] = n, (index[0], count[0])
 /// corresponds to the nth bucket.
 #[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
 pub struct SparseHistogram {
     /// parameters representing the resolution and the range of
     /// the histogram tracking request latencies

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = [
 	"Brian Martin <brian@iop.systems>",

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -17,7 +17,7 @@ links = "metriken"
 
 [dependencies]
 metriken-derive = { version = "0.2.0", path = "./derive" }
-histogram = { version = "0.8.0", path = "../histogram" }
+histogram = { version = "0.8.2", path = "../histogram" }
 
 linkme = "0.3.3"
 once_cell = "1.14.0"

--- a/ringlog/Cargo.toml
+++ b/ringlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ringlog"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Brian Martin <brian@pelikan.io>"]

--- a/ringlog/Cargo.toml
+++ b/ringlog/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/pelikan-io/rustcommon"
 [dependencies]
 ahash = "0.8.0"
 clocksource = { version = "0.6.0" }
-metriken = { version = "0.3.0", path = "../metriken" }
+metriken = { version = "0.3.2", path = "../metriken" }
 log = { version = "0.4.17", features = ["std"] }
 mpmc = "0.1.6"


### PR DESCRIPTION
Add a sparse representation of the histogram which only stores non-zero
buckets. Optionally add serde bindings to the SparseHistogram so that
it can be serialized as a storage format. The histogram store's bucket
data in a columnar representation, with the indices and the values stored
in individual arrays, as this results in smaller footprint when serialized.