### PR TITLE
update ratelimit to use clocksource 0.7.1

### DIFF
--- a/ratelimit/Cargo.toml
+++ b/ratelimit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratelimit"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -9,6 +9,6 @@ homepage = "https://github.com/pelikan-io/rustcommon/ratelimit"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
-clocksource = { version = "0.6.0" }
+clocksource = { version = "0.7.1" }
 parking_lot = "0.12.1"
 thiserror = "1.0.40"

--- a/ratelimit/Cargo.toml
+++ b/ratelimit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratelimit"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/ratelimit/src/lib.rs
+++ b/ratelimit/src/lib.rs
@@ -105,10 +105,10 @@ impl Ratelimiter {
     }
 
     /// Return the current interval between refills.
-    pub fn refill_interval(&self) -> Duration {
+    pub fn refill_interval(&self) -> core::time::Duration {
         let parameters = self.parameters.read();
 
-        Duration::from_nanos(parameters.refill_interval.as_nanos())
+        core::time::Duration::from_nanos(parameters.refill_interval.as_nanos())
     }
 
     /// Allows for changing the interval between refills at runtime.
@@ -216,10 +216,8 @@ impl Ratelimiter {
             intervals = (time - refill_at).as_nanos() / parameters.refill_interval.as_nanos() + 1;
 
             // calculate when the following refill would be
-            let next_refill = refill_at
-                + Duration::from_nanos(
-                    intervals * parameters.refill_interval.as_nanos(),
-                );
+            let next_refill =
+                refill_at + Duration::from_nanos(intervals * parameters.refill_interval.as_nanos());
 
             // compare/exchange, if race, loop and check if we still need to
             // refill before trying again
@@ -394,10 +392,7 @@ impl Builder {
         };
 
         let refill_at = AtomicInstant::new(
-            Instant::now()
-                + Duration::from_nanos(
-                    self.refill_interval.as_nanos() as u64,
-                ),
+            Instant::now() + self.refill_interval,
         );
 
         Ok(Ratelimiter {

--- a/ratelimit/src/lib.rs
+++ b/ratelimit/src/lib.rs
@@ -53,14 +53,10 @@
 //! }
 //! ```
 
-use clocksource::Nanoseconds;
+use clocksource::precise::{AtomicInstant, Duration, Instant};
 use core::sync::atomic::{AtomicU64, Ordering};
 use parking_lot::RwLock;
 use thiserror::Error;
-
-type Duration = clocksource::Duration<Nanoseconds<u64>>;
-type Instant = clocksource::Instant<Nanoseconds<u64>>;
-type AtomicInstant = clocksource::Instant<Nanoseconds<AtomicU64>>;
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
@@ -221,7 +217,7 @@ impl Ratelimiter {
 
             // calculate when the following refill would be
             let next_refill = refill_at
-                + clocksource::Duration::<Nanoseconds<u64>>::from_nanos(
+                + Duration::from_nanos(
                     intervals * parameters.refill_interval.as_nanos(),
                 );
 
@@ -399,7 +395,7 @@ impl Builder {
 
         let refill_at = AtomicInstant::new(
             Instant::now()
-                + clocksource::Duration::<Nanoseconds<u64>>::from_nanos(
+                + Duration::from_nanos(
                     self.refill_interval.as_nanos() as u64,
                 ),
         );

--- a/ratelimit/src/lib.rs
+++ b/ratelimit/src/lib.rs
@@ -391,9 +391,7 @@ impl Builder {
             refill_interval: Duration::from_nanos(self.refill_interval.as_nanos() as u64),
         };
 
-        let refill_at = AtomicInstant::new(
-            Instant::now() + self.refill_interval,
-        );
+        let refill_at = AtomicInstant::new(Instant::now() + self.refill_interval);
 
         Ok(Ratelimiter {
             available,

--- a/ratelimit/src/lib.rs
+++ b/ratelimit/src/lib.rs
@@ -444,8 +444,8 @@ mod tests {
             }
         }
 
-        assert!(count >= 800);
-        assert!(count <= 1200);
+        assert!(count >= 600);
+        assert!(count <= 1400);
     }
 
     // quick test that an idle ratelimiter doesn't build up excess capacity


### PR DESCRIPTION
Updates ratelimit to use clocksource 0.7.1

Resolves #89 