### PR TITLE
Add schemars integration to histogram

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/pelikan-io/rustcommon"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]
+schemars = { version = "0.8", optional = true }
 serde = { version = "1.0.144", features = ["derive"], optional = true }
 thiserror = "1.0.47"
 
@@ -17,6 +18,7 @@ criterion = "0.5.1"
 rand = "0.8.5"
 
 [features]
+schemars = ["dep:schemars", "serde-serialize"]
 serde-serialize = ["serde"]
 
 [[bench]]

--- a/histogram/src/config.rs
+++ b/histogram/src/config.rs
@@ -57,6 +57,7 @@ use serde::{Deserialize, Serialize};
 /// * `max_value_power` must be greater than `grouping_power
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Config {
     max: u64,
     grouping_power: u8,

--- a/histogram/src/sparse.rs
+++ b/histogram/src/sparse.rs
@@ -11,6 +11,7 @@ use crate::{Bucket, Config, Error, Histogram, Snapshot};
 /// corresponds to the nth bucket.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SparseHistogram {
     /// parameters representing the resolution and the range of
     /// the histogram tracking request latencies


### PR DESCRIPTION
I would like to add a schemars integration to rpcperf-dataspec but since it depends on the histogram crate I need to add support here first.

The details are pretty straightforward:
- I've added a new `schemars` feature to `histogram` - it also enables the `serde-serialize` feature
- I've added a `#[derive(JsonSchema)]` anywhere there was an existing `#[derive(Serialize, Deserialize)]` annotation.

That's it.

I'm not entirely sure how things will work if `schemars` performs a new major version bump but it seems to update fairly slowly so it is unlikely to be a problem for a few years.
