### PR TITLE
Update dependencies for metriken-derive

### DIFF
--- a/metriken/derive/Cargo.toml
+++ b/metriken/derive/Cargo.toml
@@ -2,7 +2,10 @@
 name = "metriken-derive"
 version = "0.5.0"
 edition = "2021"
-authors = ["Brian Martin <brian@pelikan.io>", "Sean Lynch <seanl@twitter.com>"]
+authors = [
+	"Brian Martin <brian@pelikan.io>",
+	"Sean Lynch <sean@iop.systems>"
+]
 license = "Apache-2.0"
 description = "Proc macros for metriken"
 homepage = "https://github.com/pelikan-io/rustcommon"

--- a/metriken/derive/Cargo.toml
+++ b/metriken/derive/Cargo.toml
@@ -2,10 +2,7 @@
 name = "metriken-derive"
 version = "0.5.0"
 edition = "2021"
-authors = [
-	"Brian Martin <brian@pelikan.io>",
-	"Sean Lynch <seanl@twitter.com>",
-]
+authors = ["Brian Martin <brian@pelikan.io>", "Sean Lynch <seanl@twitter.com>"]
 license = "Apache-2.0"
 description = "Proc macros for metriken"
 homepage = "https://github.com/pelikan-io/rustcommon"
@@ -17,6 +14,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0.39"
-proc-macro-crate = "1.0.0"
+proc-macro-crate = "3.0.0"
 quote = "1.0.9"
-syn = { version = "1.0.95", features = ["full", "parsing"] }
+syn = { version = "2.0", features = ["full", "parsing"] }


### PR DESCRIPTION
No point in using outdated versions of proc-macro-crate and syn
