### PR TITLE
Add a basic readme to all the metriken crates

### DIFF
--- a/metriken/README.md
+++ b/metriken/README.md
@@ -1,0 +1,38 @@
+# metriken
+
+Easily registered distributed metrics.
+
+`metriken` allows you to easily declare static metrics throughout your codebase.
+Then, when you want to expose those metrics, you can access them all in one
+place.
+
+```rust
+use metriken::{metric, Counter, Gauge, Value};
+
+/// A counter metric named "<crate name>::COUNTER"
+#[metric]
+static COUNTER: Counter = Counter::new();
+
+/// A gauge metric named "my.metric"
+#[metric(name = "my.metric")]
+static GAUGE: Gauge = Gauge::new();
+
+fn main() {
+    COUNTER.increment();
+
+    for metric in &metriken::metrics() {
+        let name = metric.name();
+
+        match metric.value() {
+            Some(Value::Counter(val)) => println!("{name}: {val}"),
+            Some(Value::Gauge(val)) => println!("{name}: {val}"),
+            _ => println!("{name}: <custom>")
+        }
+    }
+}
+```
+
+Code updating the metrics can always access them without needing to go through
+any indirections. (It just means accessing a static!). Using `linkme`, the
+metrics are all gathered into a single global array that can then be used to
+read all of them and expose them.

--- a/metriken/core/README.md
+++ b/metriken/core/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/metriken/derive/README.md
+++ b/metriken/derive/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/metriken/src/lib.rs
+++ b/metriken/src/lib.rs
@@ -30,7 +30,7 @@
 //! # assert_eq!(names[0], "COUNTER_A");
 //! # assert_eq!(names[1], "my.metric.name");
 //! ```
-//! 
+//!
 //! If you want to create and remove metrics dynamically at runtime check out
 //! the [`dynmetrics`] module.
 //!

--- a/metriken/src/lib.rs
+++ b/metriken/src/lib.rs
@@ -4,8 +4,6 @@
 
 //! Easily registered distributed metrics.
 //!
-//! More docs todo...
-//!
 //! # Creating a Metric
 //! Registering a metric is straightforward. All that's needed is to declare a
 //! static within the [`metric`] macro. By default, the metric will have the
@@ -32,6 +30,9 @@
 //! # assert_eq!(names[0], "COUNTER_A");
 //! # assert_eq!(names[1], "my.metric.name");
 //! ```
+//! 
+//! If you want to create and remove metrics dynamically at runtime check out
+//! the [`dynmetrics`] module.
 //!
 //! # Accessing Metrics
 //! All metrics registered via the [`metric`] macro can be accessed by calling
@@ -116,3 +117,8 @@ pub type LazyGauge = Lazy<Gauge>;
 pub mod export {
     pub use metriken_core::declare_metric_v1;
 }
+
+#[cfg(doc)]
+#[doc = include_str!("../README.md")]
+#[doc(hidden)]
+pub mod readme {}


### PR DESCRIPTION
Currently none of these crates have a readme on crates.io. That's not great so this PR adds one.