### PR TITLE
Ignore test `histogram::standard::tests::downsample`

### DIFF
--- a/histogram/src/standard.rs
+++ b/histogram/src/standard.rs
@@ -345,6 +345,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "this test is flaky (see issue #100)"]
     // Tests downsampling
     fn downsample() {
         let mut histogram = Histogram::new(8, 32).unwrap();


### PR DESCRIPTION
This test is flaky. I have opened an issue to track it at https://github.com/pelikan-io/rustcommon/issues/100
