### PR TITLE
Fix unbounded recursion in Metric impl for CoreMetric (metriken v0.4.2) 

### DIFF
--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = [
 	"Brian Martin <brian@iop.systems>",

--- a/metriken/src/lib.rs
+++ b/metriken/src/lib.rs
@@ -165,15 +165,15 @@ pub mod export {
 
     impl<T: Metric> metriken_core::Metric for WrapMetric<T> {
         fn is_enabled(&self) -> bool {
-            <Self as Metric>::is_enabled(self)
+            <T as Metric>::is_enabled(self)
         }
 
         fn as_any(&self) -> Option<&dyn std::any::Any> {
-            <Self as Metric>::as_any(self)
+            <T as Metric>::as_any(self)
         }
 
         fn value(&self) -> Option<metriken_core::Value> {
-            let value = <Self as Metric>::value(self)?;
+            let value = <T as Metric>::value(self)?;
 
             Some(match value {
                 crate::Value::Counter(val) => metriken_core::Value::Counter(val),
@@ -310,17 +310,17 @@ impl std::fmt::Debug for MetricEntry {
 
 impl<T: metriken_core::Metric> Metric for T {
     fn is_enabled(&self) -> bool {
-        <Self as metriken_core::Metric>::is_enabled(self)
+        <T as metriken_core::Metric>::is_enabled(self)
     }
 
     fn as_any(&self) -> Option<&dyn Any> {
-        <Self as metriken_core::Metric>::as_any(self)
+        <T as metriken_core::Metric>::as_any(self)
     }
 
     fn value(&self) -> Option<Value> {
         use metriken_core::Value as CoreValue;
 
-        Some(match <Self as metriken_core::Metric>::value(self)? {
+        Some(match <T as metriken_core::Metric>::value(self)? {
             CoreValue::Counter(val) => Value::Counter(val),
             CoreValue::Gauge(val) => Value::Gauge(val),
             CoreValue::Other(val) => {

--- a/metriken/tests/as_any.rs
+++ b/metriken/tests/as_any.rs
@@ -1,0 +1,14 @@
+use metriken::{metric, Counter, metrics};
+
+#[metric]
+static THE_METRIC: Counter = Counter::new();
+
+#[test]
+fn as_any_does_not_recurse_infinitely() {
+    let metrics = metrics().static_metrics();
+    let metric = metrics.iter().find(|entry| entry.is(&THE_METRIC)).unwrap();
+
+    let counter = metric.as_any().unwrap().downcast_ref::<Counter>().unwrap();
+
+    assert_eq!(counter.value(), THE_METRIC.value());
+}

--- a/metriken/tests/as_any.rs
+++ b/metriken/tests/as_any.rs
@@ -1,4 +1,4 @@
-use metriken::{metric, Counter, metrics};
+use metriken::{metric, metrics, Counter};
 
 #[metric]
 static THE_METRIC: Counter = Counter::new();


### PR DESCRIPTION
This copies the same PR from #104 but bases it on the `metriken-v4` branch.