### PR TITLE
clocksource: add additional methods for coarse duration

### DIFF
--- a/clocksource/Cargo.toml
+++ b/clocksource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clocksource"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 description = "Library for times and durations with fixed-size representations"

--- a/clocksource/src/coarse/duration.rs
+++ b/clocksource/src/coarse/duration.rs
@@ -4,8 +4,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, Sub, SubAss
 /// A duration measured in seconds.
 ///
 /// A duration represents a span of time. Unlike `std::time::Instant` the
-/// internal representation uses only nanoseconds in a u64 field to represent
-/// the span of time. This means that the max duration is ~584 years.
+/// internal representation uses only seconds in a u32 field to represent
+/// the span of time. This means that the max duration is ~136 years.
 #[repr(transparent)]
 #[derive(Copy, Clone, Default, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Duration {

--- a/clocksource/src/coarse/duration.rs
+++ b/clocksource/src/coarse/duration.rs
@@ -1,3 +1,4 @@
+use crate::{MICROS_PER_SEC, MILLIS_PER_SEC, NANOS_PER_SEC};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, Sub, SubAssign};
 
 /// A duration measured in seconds.
@@ -31,6 +32,21 @@ impl Duration {
     /// Returns the number of seconds contained by this `Duration` as `f64`.
     pub const fn as_secs_f64(&self) -> f64 {
         self.secs as f64
+    }
+
+    /// Returns the number of microseconds contained by this `Duration`.
+    pub const fn as_micros(&self) -> u64 {
+        self.secs as u64 * MICROS_PER_SEC
+    }
+
+    /// Returns the number of milliseconds contained by this `Duration`.
+    pub const fn as_millis(&self) -> u64 {
+        self.secs as u64 * MILLIS_PER_SEC
+    }
+
+    /// Returns the number of nanoseconds contained by this `Duration`.
+    pub const fn as_nanos(&self) -> u64 {
+        self.secs as u64 * NANOS_PER_SEC
     }
 }
 

--- a/clocksource/src/lib.rs
+++ b/clocksource/src/lib.rs
@@ -15,3 +15,7 @@ pub mod datetime;
 pub mod precise;
 
 mod sys;
+
+const MILLIS_PER_SEC: u64 = 1_000;
+const MICROS_PER_SEC: u64 = 1_000_000;
+const NANOS_PER_SEC: u64 = 1_000_000_000;

--- a/clocksource/src/sys/windows.rs
+++ b/clocksource/src/sys/windows.rs
@@ -1,6 +1,5 @@
+use crate::NANOS_PER_SEC;
 use core::sync::atomic::{AtomicU64, Ordering};
-
-const NANOS_PER_SEC: u64 = 1_000_000_000;
 
 pub mod monotonic {
     use super::*;


### PR DESCRIPTION
Adds a few additional methods for coarse duration to return other units.
