### PR TITLE
expand serde coverage for histogram crate

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Brian Martin <brian@pelikan.io>"]
 license = "MIT OR Apache-2.0"

--- a/histogram/src/snapshot.rs
+++ b/histogram/src/snapshot.rs
@@ -3,6 +3,7 @@ use std::time::SystemTime;
 
 /// A snapshot of a histogram across a time range.
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Snapshot {
     // note: `Histogram` contains the start time
     pub(crate) end: SystemTime,

--- a/histogram/src/sparse.rs
+++ b/histogram/src/sparse.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 use crate::{Bucket, Config, Error, Histogram, Snapshot};
 
 /// This histogram is a sparse, columnar representation of the regular
@@ -10,7 +7,7 @@ use crate::{Bucket, Config, Error, Histogram, Snapshot};
 /// of non-zero buckets. Assuming index[0] = n, (index[0], count[0])
 /// corresponds to the nth bucket.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SparseHistogram {
     /// parameters representing the resolution and the range of

--- a/histogram/src/standard.rs
+++ b/histogram/src/standard.rs
@@ -3,6 +3,7 @@ use std::time::SystemTime;
 
 /// A histogram that uses plain 64bit counters for each bucket.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Histogram {
     pub(crate) config: Config,
     pub(crate) start: SystemTime,

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.5.2"
+version = "0.5.1"
 edition = "2021"
 authors = [
 	"Brian Martin <brian@iop.systems>",
@@ -14,7 +14,7 @@ repository = "https://github.com/pelikan-io/rustcommon"
 [dependencies]
 metriken-core = { version = "0.1", path = "core" }
 metriken-derive = { version = "=0.5.1", path = "./derive" }
-histogram = { version = "0.9.1", path = "../histogram" }
+histogram = { version = "0.9.0", path = "../histogram" }
 
 once_cell = "1.14.0"
 parking_lot = "0.12.1"

--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriken"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = [
 	"Brian Martin <brian@iop.systems>",
@@ -14,7 +14,7 @@ repository = "https://github.com/pelikan-io/rustcommon"
 [dependencies]
 metriken-core = { version = "0.1", path = "core" }
 metriken-derive = { version = "=0.5.1", path = "./derive" }
-histogram = { version = "0.9.0", path = "../histogram" }
+histogram = { version = "0.9.1", path = "../histogram" }
 
 once_cell = "1.14.0"
 parking_lot = "0.12.1"

--- a/ringlog/Cargo.toml
+++ b/ringlog/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/pelikan-io/rustcommon"
 [dependencies]
 ahash = "0.8.0"
 clocksource = { version = "0.8.0", path = "../clocksource" }
-metriken = { version = "0.5.2", path = "../metriken" }
+metriken = { version = "0.5.1", path = "../metriken" }
 log = { version = "0.4.17", features = ["std"] }
 mpmc = "0.1.6"

--- a/ringlog/Cargo.toml
+++ b/ringlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ringlog"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Brian Martin <brian@pelikan.io>"]
@@ -11,6 +11,6 @@ repository = "https://github.com/pelikan-io/rustcommon"
 [dependencies]
 ahash = "0.8.0"
 clocksource = { version = "0.8.0", path = "../clocksource" }
-metriken = { version = "0.4.0" }
+metriken = { version = "0.5.2", path = "../metriken" }
 log = { version = "0.4.17", features = ["std"] }
 mpmc = "0.1.6"


### PR DESCRIPTION
Expands serde coverage for histogram crate.

Updates metriken to use latest histogram version.

Updates ringlog to use latest metriken version.
