### PR TITLE
ratelimit: add tracking for number of dropped tokens

### DIFF
--- a/ratelimit/Cargo.toml
+++ b/ratelimit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratelimit"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Adds a tracking counter for the number of tokens dropped due to bucket overflow.
