### PR TITLE
histogram: add subtract operation for sparse histograms

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 authors = ["Brian Martin <brian@pelikan.io>"]
 license = "MIT OR Apache-2.0"

--- a/histogram/src/errors.rs
+++ b/histogram/src/errors.rs
@@ -18,4 +18,8 @@ pub enum Error {
     IncompatibleTimeRange,
     #[error("an overflow occurred")]
     Overflow,
+    #[error("an underflow occurred")]
+    Underflow,
+    #[error("the histogram is not a subset")]
+    InvalidSubset,
 }


### PR DESCRIPTION
Allow a histogram to be subtracted from another, as long as it
is a proper subset of the other histogram. This is a diff operation
and allows delta histograms to be extracted from free-running ones.