### PR TITLE
histogram: fix percentiles for empty histograms

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Brian Martin <brian@pelikan.io>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
When the histogram is empty, the percentiles function
currently returns the first bucket for the standard
histogram and panics due to an underflow in the sparse
histogram. Change the signature to return an Optional
value, which is set to None in the empty histogram case
for both standard and sparse histograms.

Also, add a batched percentile lookup for the sparse
histogram to bring the interface in line with the
standard histogram.