### PR TITLE
run size tests only on 64bit platforms

### DIFF
--- a/histogram/src/atomic.rs
+++ b/histogram/src/atomic.rs
@@ -81,6 +81,7 @@ impl AtomicHistogram {
 mod test {
     use crate::*;
 
+    #[cfg(target_pointer_width = "64")]
     #[test]
     fn size() {
         assert_eq!(std::mem::size_of::<AtomicHistogram>(), 48);

--- a/histogram/src/config.rs
+++ b/histogram/src/config.rs
@@ -206,6 +206,7 @@ impl Config {
 mod tests {
     use super::*;
 
+    #[cfg(target_pointer_width = "64")]
     #[test]
     fn sizes() {
         assert_eq!(std::mem::size_of::<Config>(), 32);

--- a/histogram/src/standard.rs
+++ b/histogram/src/standard.rs
@@ -306,6 +306,7 @@ mod tests {
     use super::*;
     use rand::Rng;
 
+    #[cfg(target_pointer_width = "64")]
     #[test]
     fn size() {
         assert_eq!(std::mem::size_of::<Histogram>(), 48);


### PR DESCRIPTION
We have some size tests in the histogram crate that are sensitive to the platform pointer width. As such, they fail on 32bit systems as reported in #123 

This change restricts these tests to only run on platforms with the expected pointer width. 