### PR TITLE
fix homepage links in cargo manifests

### DIFF
--- a/ratelimit/Cargo.toml
+++ b/ratelimit/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A simple ratelimiter that can be shared between threads"
-homepage = "https://github.com/pelikan-io/rustcommon/ratelimit"
+homepage = "https://github.com/pelikan-io/rustcommon"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]

--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "Generates waterfalls from heatmaps"
-homepage = "https://github.com/pelikan-io/rustcommon/waterfall"
+homepage = "https://github.com/pelikan-io/rustcommon"
 repository = "https://github.com/pelikan-io/rustcommon"
 
 [dependencies]


### PR DESCRIPTION
As reported in #122 we have some broken links. This change updates those links to point to the github repo.
