### PR TITLE
prepare for releases

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["Brian Martin <brian@pelikan.io>"]
 license = "MIT OR Apache-2.0"

--- a/ratelimit/Cargo.toml
+++ b/ratelimit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratelimit"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/waterfall/Cargo.toml
+++ b/waterfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterfall"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Update version number to prepare for releases for:
* histogram 0.11.1
* ratelimit 0.10.0
* waterfall 0.8.2
