### PR TITLE
histogram: prepare for release 0.11.2

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 authors = ["Brian Martin <brian@pelikan.io>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Prepare histogram crate release 0.11.2

Adds `.iter()` for standard histogram.
