### PR TITLE
fix: percentile now properly finds the min bucket

### DIFF
--- a/histogram/Cargo.toml
+++ b/histogram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 authors = ["Brian Martin <brian@pelikan.io>"]
 license = "MIT OR Apache-2.0"

--- a/histogram/src/sparse.rs
+++ b/histogram/src/sparse.rs
@@ -287,7 +287,7 @@ pub struct Iter<'a> {
     histogram: &'a SparseHistogram,
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = Bucket;
 
     fn next(&mut self) -> Option<<Self as std::iter::Iterator>::Item> {


### PR DESCRIPTION
Previously, the percentiles functions would report the first bucket as the 0.0th percentile, even if it was empty. We would expect instead that it returns the first bucket with a non-zero count.

This fix wraps the calculation so that low percentiles will always need to find a bucket with at least a count of one.

As a result, percentiles() can now be used to find the proper min, max, and any other percentiles one may need to report out.

Fixes #133 