### PR TITLE
Fix sampling builder zero handling

### DIFF
--- a/ringlog/src/sampling.rs
+++ b/ringlog/src/sampling.rs
@@ -102,6 +102,9 @@ impl SamplingLogBuilder {
 
     /// Consumes the builder and returns a configured `SamplingLogger` and `LogDrain`.
     pub(crate) fn build_raw(self) -> Result<(SamplingLogger, LogDrain), &'static str> {
+        if self.sample == 0 {
+            return Err("sample cannot be zero");
+        }
         let (logger, log_handle) = self.log_builder.build_raw()?;
         let logger = SamplingLogger {
             logger,


### PR DESCRIPTION
## Summary
- guard `SamplingLogBuilder` from panicking when zero is passed
- return a build-time error if the sampling value is zero

## Testing
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_b_683f4af4fd34832ab0e629bc023a5653