### PR TITLE
Update CI GitHub Actions versions

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -26,7 +26,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -42,7 +42,7 @@ jobs:
             | sarif-fmt
         shell: bash
         continue-on-error: true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: clippy-sarif
           path: clippy.sarif
@@ -53,8 +53,8 @@ jobs:
     permissions:
       security-events: write
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
       with:
         name: clippy-sarif
     - uses: github/codeql-action/upload-sarif@v2
@@ -64,7 +64,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: check-ubuntu-latest
@@ -79,7 +79,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: cargo fmt
         shell: bash
@@ -96,7 +96,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         profile: [ release, debug ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- update `actions/checkout` to `v4`
- update `actions/upload-artifact` and `actions/download-artifact` to `v4`

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_b_683f70d52304832a820d700050bcb0b2