### PR TITLE
Update copyright and add NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Rustcommon
+Copyright 2022-2026 The Authors
+
+This project is based on Twitter's Rustcommon project
+Copyright 2020-2022 Twitter, Inc.
+https://github.com/twitter/rustcommon


### PR DESCRIPTION
## Summary
- Add NOTICE file with copyright attribution (Twitter 2020-2022, The Authors 2022-2026) and link to the original fork
- Remove per-file copyright and license headers from all source files (license info already covered by repo-level LICENSE-MIT and LICENSE-APACHE)

## Test plan
- [x] No code changes, only copyright/license housekeeping

🤖 Generated with [Claude Code](https://claude.com/claude-code)